### PR TITLE
Don't assume the OSD node also is a mon node

### DIFF
--- a/recipes/monitoring.rb
+++ b/recipes/monitoring.rb
@@ -72,7 +72,6 @@ nrpe_check 'check_ceph_osd' do
   command ::File.join(node['nrpe']['plugin_dir'], 'check_ceph_osd')
   parameters [
     "-i #{keyname}",
-    "-m #{node['ipaddress']}",
     "-C #{nrpe['check_ceph_osd']['critical']}",
     "-H #{node['ipaddress']}"
   ].join(' ')

--- a/spec/unit/recipes/monitoring_spec.rb
+++ b/spec/unit/recipes/monitoring_spec.rb
@@ -58,7 +58,7 @@ describe 'osl-ceph::monitoring' do
         expect(chef_run).to add_nrpe_check('check_ceph_osd')
           .with(
             command: '/usr/lib64/nagios/plugins/check_ceph_osd',
-            parameters: '-i nagios-Fauxhai -m 10.0.0.2 -C 1 -H 10.0.0.2'
+            parameters: '-i nagios-Fauxhai -C 1 -H 10.0.0.2'
           )
       end
       it do


### PR DESCRIPTION
In clusters where we have the MON nodes split up from the OSD nodes, this breaks
NRPE checks. This just uses what's in the ceph.conf to figure out where to
query.