### PR TITLE
Update test environment to use sdX instead of vdX

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -34,17 +34,17 @@ provisioner:
         role: 'ceph_osd'
         devices:
           -
-            data: '/dev/vdd1'
-            block_db: '/dev/vdb1'
-            block_wal: '/dev/vdc1'
+            data: '/dev/sdd1'
+            block_db: '/dev/sdb1'
+            block_wal: '/dev/sdc1'
           -
-            data: '/dev/vde1'
-            block_db: '/dev/vdb2'
-            block_wal: '/dev/vdc2'
+            data: '/dev/sde1'
+            block_db: '/dev/sdb2'
+            block_wal: '/dev/sdc2'
           -
-            data: '/dev/vdf1'
-            block_db: '/dev/vdb3'
-            block_wal: '/dev/vdc3'
+            data: '/dev/sdf1'
+            block_db: '/dev/sdb3'
+            block_wal: '/dev/sdc3'
     ceph_test:
       openstack_auth_url: <%= "#{ENV['OS_AUTH_URL']}/tokens" %>
       openstack_username: <%= ENV['OS_USERNAME'] %>

--- a/test/cookbooks/ceph_test/recipes/default.rb
+++ b/test/cookbooks/ceph_test/recipes/default.rb
@@ -15,21 +15,21 @@ end
 execute 'create volumes' do
   command '/root/volume.rb'
   live_stream true
-  creates '/dev/vdf'
+  creates '/dev/sdf'
 end
 
 # Format wal and blk devices
 ('b'..'c').to_a.each do |i|
   execute "create ssd#{i}" do
     command <<-EOF
-      parted --script /dev/vd#{i} \
+      parted --script /dev/sd#{i} \
         mklabel gpt \
         mkpart primary 1MiB 512MiB \
         mkpart primary 512MiB 1Gib \
         mkpart primary 1Gib 1.5Gib \
         mkpart primary 1.5Gib 2Gib
     EOF
-    creates "/dev/vd#{i}1"
+    creates "/dev/sd#{i}1"
   end
 end
 
@@ -37,10 +37,10 @@ end
 ('d'..'f').to_a.each do |i|
   execute "create osd#{i}" do
     command <<-EOF
-      parted --script /dev/vd#{i} \
+      parted --script /dev/sd#{i} \
         mklabel gpt \
         mkpart primary 1 100%
     EOF
-    creates "/dev/vd#{i}1"
+    creates "/dev/sd#{i}1"
   end
 end

--- a/test/cookbooks/ceph_test/templates/default/volume.rb.erb
+++ b/test/cookbooks/ceph_test/templates/default/volume.rb.erb
@@ -13,7 +13,7 @@ compute_client ||= ::Fog::Compute.new(@connection_params)
 begin
   vm = compute_client.servers.get('<%= @vm_uuid %>')
   compute_client.volumes.all(options: true).each do |volume|
-    if volume.name =~ /ceph-test-#{vm.name}-vd[a-z]/
+    if volume.name =~ /ceph-test-#{vm.name}-sd[a-z]/
       if volume.ready?
         puts "deleting #{volume.name}"
         volume.destroy
@@ -23,16 +23,16 @@ begin
   # let things settle for five seconds
   sleep 5
   ('b'..'f').to_a.each do |i|
-    puts "creating ceph-test-#{vm.name}-vd#{i}-#{vm.id}"
-    volume = compute_client.volumes.create name: "ceph-test-#{vm.name}-vd#{i}-#{vm.id}", size: 4, description: ''
+    puts "creating ceph-test-#{vm.name}-sd#{i}-#{vm.id}"
+    volume = compute_client.volumes.create name: "ceph-test-#{vm.name}-sd#{i}-#{vm.id}", size: 4, description: ''
     volume.reload
     until volume.ready?
       puts "volume #{volume.name} not ready, waiting.."
       volume.reload
       sleep 2
     end
-    puts "attaching ceph-test-#{vm.name}-vd#{i} to #{vm.name}"
-    vm.attach_volume(volume.id, "/dev/vd#{i}")
+    puts "attaching ceph-test-#{vm.name}-sd#{i} to #{vm.name}"
+    vm.attach_volume(volume.id, "/dev/sd#{i}")
   end
   sleep 5
 

--- a/test/integration/roles/ceph.json
+++ b/test/integration/roles/ceph.json
@@ -15,20 +15,20 @@
         "role": "ceph_osd",
         "devices": [
           {
-            "data": "/dev/vdd1",
-            "block_db": "/dev/vdb1",
-            "block_wal": "/dev/vdc1"
+            "data": "/dev/sdd1",
+            "block_db": "/dev/sdb1",
+            "block_wal": "/dev/sdc1"
           },
 
           {
-            "data": "/dev/vde1",
-            "block_db": "/dev/vdb2",
-            "block_wal": "/dev/vdc2"
+            "data": "/dev/sde1",
+            "block_db": "/dev/sdb2",
+            "block_wal": "/dev/sdc2"
           },
           {
-            "data": "/dev/vdf1",
-            "block_db": "/dev/vdb3",
-            "block_wal": "/dev/vdc3"
+            "data": "/dev/sdf1",
+            "block_db": "/dev/sdb3",
+            "block_wal": "/dev/sdc3"
           }
         ]
       },


### PR DESCRIPTION
With the switch to actually using Ceph in the backend, we've updated the how the
system see the disks as well. So now instead of seeing vda we see sda for
example. This makes no changes for production and only in test-kitchen and chef
provisioning test environments