### PR TITLE
Split nagios plugin installation into its own recipe

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -75,3 +75,6 @@ suites:
       - role[ceph_mgr]
       - role[ceph_osd]
       - recipe[osl-ceph::monitoring]
+  - name: nagios
+    run_list:
+      - recipe[osl-ceph::nagios]

--- a/recipes/monitoring.rb
+++ b/recipes/monitoring.rb
@@ -15,29 +15,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-include_recipe 'osl-ceph'
-include_recipe 'osl-nrpe'
-include_recipe 'git'
-
-ceph_nagios = ::File.join(Chef::Config[:file_cache_path], 'ceph-nagios')
-
-git ceph_nagios do
-  repository 'https://github.com/osuosl/ceph-nagios-plugins.git'
-  ignore_failure true
-end
-
-%w(
-  check_ceph_df
-  check_ceph_health
-  check_ceph_mds
-  check_ceph_mon
-  check_ceph_osd
-  check_ceph_rgw
-).each do |check|
-  link ::File.join(node['nrpe']['plugin_dir'], check) do
-    to ::File.join(ceph_nagios, 'src', check)
-  end
-end
+include_recipe 'osl-ceph::nagios'
 
 keyname = "nagios-#{node['hostname']}"
 

--- a/recipes/nagios.rb
+++ b/recipes/nagios.rb
@@ -1,0 +1,40 @@
+#
+# Cookbook:: osl-ceph
+# Recipe:: nagios
+#
+# Copyright:: 2018, Oregon State University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+include_recipe 'osl-ceph'
+include_recipe 'osl-nrpe'
+include_recipe 'git'
+
+ceph_nagios = ::File.join(Chef::Config[:file_cache_path], 'ceph-nagios')
+
+git ceph_nagios do
+  repository 'https://github.com/osuosl/ceph-nagios-plugins.git'
+  ignore_failure true
+end
+
+%w(
+  check_ceph_df
+  check_ceph_health
+  check_ceph_mds
+  check_ceph_mon
+  check_ceph_osd
+  check_ceph_rgw
+).each do |check|
+  link ::File.join(node['nrpe']['plugin_dir'], check) do
+    to ::File.join(ceph_nagios, 'src', check)
+  end
+end

--- a/spec/unit/recipes/nagios_spec.rb
+++ b/spec/unit/recipes/nagios_spec.rb
@@ -1,0 +1,32 @@
+require_relative '../../spec_helper'
+
+describe 'osl-ceph::nagios' do
+  ALL_PLATFORMS.each do |p|
+    context "#{p[:platform]} #{p[:version]}" do
+      include_context 'chef_server', p
+      it 'converges successfully' do
+        expect { chef_run }.to_not raise_error
+      end
+      it do
+        expect(chef_run).to sync_git("#{Chef::Config[:file_cache_path]}/ceph-nagios")
+          .with(
+            repository: 'https://github.com/osuosl/ceph-nagios-plugins.git',
+            ignore_failure: true
+          )
+      end
+      %w(
+        check_ceph_df
+        check_ceph_health
+        check_ceph_mds
+        check_ceph_mon
+        check_ceph_osd
+        check_ceph_rgw
+      ).each do |check|
+        it do
+          expect(chef_run).to create_link("/usr/lib64/nagios/plugins/#{check}")
+            .with(to: ::File.join(Chef::Config[:file_cache_path], 'ceph-nagios', 'src', check))
+        end
+      end
+    end
+  end
+end

--- a/test/integration/nagios/nagios_spec.rb
+++ b/test/integration/nagios/nagios_spec.rb
@@ -1,0 +1,12 @@
+%w(
+  check_ceph_df
+  check_ceph_health
+  check_ceph_mds
+  check_ceph_mon
+  check_ceph_osd
+  check_ceph_rgw
+).each do |plugin|
+  describe command("/usr/lib64/nagios/plugins/#{plugin} -h") do
+    its('exit_status') { should eq 0 }
+  end
+end


### PR DESCRIPTION
This allows us to use this recipe in other places where we don't need to setup
ceph keys such as in osl-nagios.