### PR TITLE
Remove execute[change-ceph-conf-perm] resource

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -34,6 +34,8 @@ include_recipe 'firewall::ceph'
 include_recipe 'ceph-chef'
 include_recipe 'ceph-chef::repo'
 
+delete_resource(:execute, 'change-ceph-conf-perm')
+
 directory '/etc/ceph' do
   owner node['ceph']['owner']
   group node['ceph']['group']


### PR DESCRIPTION
The execute[change-ceph-conf-perm] resource does a blanket chown -R ceph:ceph
/etc/ceph which interferes with setting files inside of the directory.