### PR TITLE
Add MDS (metadata server) recipe

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -21,6 +21,8 @@ provisioner:
         baseurl: http://epel.osuosl.org/7/$basearch
         gpgkey: http://epel.osuosl.org/RPM-GPG-KEY-EPEL-7
     ceph:
+      keyring:
+        mon: '/etc/ceph/$cluster.mon.keyring'
       mon:
         role: 'ceph_mon'
       mds:
@@ -34,6 +36,9 @@ provisioner:
             - '10.1.100.0/24'
       osd:
         role: 'ceph_osd'
+        crush:
+          chooseleaf_type: 0
+          update: true
         devices:
           -
             data: '/dev/sdd1'
@@ -65,6 +70,15 @@ suites:
     run_list:
       - role[ceph_mon]
       - role[ceph_mgr]
+  - name: mds
+    run_list:
+      - recipe[ceph_test]
+      - role[ceph_mon]
+      - role[ceph_mgr]
+      - role[ceph_osd]
+      - recipe[ceph_test::osd]
+      - role[ceph_mds]
+      - recipe[ceph_test::mds]
   - name: osd
     run_list:
       - recipe[ceph_test]

--- a/recipes/mds.rb
+++ b/recipes/mds.rb
@@ -1,0 +1,21 @@
+#
+# Cookbook:: osl-ceph
+# Recipe:: mds
+#
+# Copyright:: 2018, Oregon State University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+include_recipe 'osl-ceph'
+include_recipe 'ceph-chef::mds'
+
+tag(node['ceph']['mds']['tag'])

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -49,6 +49,7 @@ shared_context 'common_stubs' do
     stub_command('test -s /etc/ceph/ceph.mon.keyring')
     stub_command('test -s /etc/ceph/ceph.client.admin.keyring')
     stub_command('grep \'admin\' /etc/ceph/ceph.mon.keyring')
+    stub_command('test -d /var/lib/ceph/mds/ceph-Fauxhai')
     stub_command('test -s /var/lib/ceph/mon/ceph-Fauxhai/keyring')
     stub_command('test -f /var/lib/ceph/mon/ceph-Fauxhai/done')
     stub_command('test -d /var/lib/ceph/mgr/ceph-Fauxhai')

--- a/spec/unit/recipes/mds_spec.rb
+++ b/spec/unit/recipes/mds_spec.rb
@@ -1,0 +1,12 @@
+require_relative '../../spec_helper'
+
+describe 'osl-ceph::mds' do
+  ALL_PLATFORMS.each do |p|
+    context "#{p[:platform]} #{p[:version]}" do
+      include_context 'chef_server', p
+      it 'converges successfully' do
+        expect { chef_run }.to_not raise_error
+      end
+    end
+  end
+end

--- a/test/cookbooks/ceph_test/files/default/crush_map_decompressed
+++ b/test/cookbooks/ceph_test/files/default/crush_map_decompressed
@@ -1,0 +1,60 @@
+# begin crush map
+tunable choose_local_tries 0
+tunable choose_local_fallback_tries 0
+tunable choose_total_tries 50
+tunable chooseleaf_descend_once 1
+tunable chooseleaf_vary_r 1
+tunable chooseleaf_stable 1
+tunable straw_calc_version 1
+tunable allowed_bucket_algs 54
+
+# devices
+device 0 osd.0 class hdd
+device 1 osd.1 class hdd
+device 2 osd.2 class hdd
+
+# types
+type 0 osd
+type 1 host
+type 2 chassis
+type 3 rack
+type 4 row
+type 5 pdu
+type 6 pod
+type 7 room
+type 8 datacenter
+type 9 region
+type 10 root
+
+# buckets
+host node1 {
+	id -3		# do not change unnecessarily
+	id -4 class hdd		# do not change unnecessarily
+	# weight 0.012
+	alg straw2
+	hash 0	# rjenkins1
+	item osd.0 weight 0.004
+	item osd.1 weight 0.004
+	item osd.2 weight 0.004
+}
+root default {
+	id -1		# do not change unnecessarily
+	id -2 class hdd		# do not change unnecessarily
+	# weight 0.012
+	alg straw2
+	hash 0	# rjenkins1
+	item node1 weight 0.012
+}
+
+# rules
+rule replicated_rule {
+	id 0
+	type replicated
+	min_size 1
+	max_size 10
+	step take default
+	step chooseleaf firstn 0 type osd
+	step emit
+}
+
+# end crush map

--- a/test/cookbooks/ceph_test/recipes/mds.rb
+++ b/test/cookbooks/ceph_test/recipes/mds.rb
@@ -1,0 +1,7 @@
+execute 'ceph fs new cephfs cephfs_metadata cephfs_data' do
+  not_if 'ceph fs get cephfs'
+end
+
+ceph_chef_cephfs '/mnt/ceph' do
+  action [:enable, :mount]
+end

--- a/test/cookbooks/ceph_test/recipes/osd.rb
+++ b/test/cookbooks/ceph_test/recipes/osd.rb
@@ -1,0 +1,18 @@
+cookbook_file '/var/tmp/crush_map_decompressed'
+
+# This allows us to make ceph happy on a single node for testing
+execute 'update crush map' do
+  cwd '/var/tmp'
+  command <<-EOF
+    crushtool -c crush_map_decompressed -o new_crush_map_compressed
+    ceph osd setcrushmap -i new_crush_map_compressed
+  EOF
+  creates '/var/tmp/new_crush_map_compressed'
+end
+
+%w(cephfs_data cephfs_metadata).each do |p|
+  ceph_chef_pool p do
+    pg_num 32
+    pgp_num 32
+  end
+end

--- a/test/integration/mds/mds_spec.rb
+++ b/test/integration/mds/mds_spec.rb
@@ -1,0 +1,20 @@
+describe command('ceph mds stat') do
+  its('stdout') { should match(%(^cephfs-1/1/1 up  {0=node1=up:active}$)) }
+end
+
+describe command('ss -tpln') do
+  its('stdout') { should include 'ceph-mds' }
+end
+
+describe service('ceph-mds.target') do
+  it { should be_installed }
+  it { should be_enabled }
+  it { should be_running }
+end
+
+describe mount('/mnt/ceph') do
+  it { should be_mounted }
+  its('device') { should eq 'ceph-fuse' }
+  its('type') { should eq 'fuse.ceph-fuse' }
+  its('options') { should eq ['rw', 'relatime', 'user_id=0', 'group_id=0', 'allow_other'] }
+end

--- a/test/integration/mds/mgr_spec.rb
+++ b/test/integration/mds/mgr_spec.rb
@@ -1,0 +1,1 @@
+../mgr/mgr_spec.rb

--- a/test/integration/mds/mon_spec.rb
+++ b/test/integration/mds/mon_spec.rb
@@ -1,0 +1,1 @@
+../mon/mon_spec.rb

--- a/test/integration/mds/osd_spec.rb
+++ b/test/integration/mds/osd_spec.rb
@@ -1,0 +1,1 @@
+../osd/osd_spec.rb

--- a/test/integration/roles/ceph_mds.json
+++ b/test/integration/roles/ceph_mds.json
@@ -1,10 +1,7 @@
 {
   "env_run_lists": {},
   "run_list": [
-    "recipe[osl-ceph]",
-    "recipe[ceph-chef]",
-    "recipe[ceph-chef::repo]",
-    "recipe[ceph-chef::mds]"
+    "recipe[osl-ceph::mds]"
   ],
   "chef_type": "role",
   "override_attributes": {},


### PR DESCRIPTION
This adds the MDS daemon as a recipe which is required to utilize cephfs. This
required the following changes to make it happen:

- Some fixes in ceph-chef
- Update the crush map for test-kitchen to allow for single-node ceph clusters
- Create pg's for cephfs, create cephfs and mount it
- Set the mon key to something static to get it to work with test-kitchen

Edit:
**Note: running the ``test`` action on the mds suite will most likely return an error. If you want around 30 seconds and try again with ``verify`` it should pass. This is due to the fact that ceph needs a few seconds to spin things up properly**