### PR TITLE
Update to using systemd_service_drop_in

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -13,6 +13,6 @@ depends          'ceph-chef', '~> 1.1.27'
 depends          'firewall'
 depends          'git'
 depends          'osl-nrpe'
-depends          'systemd', '< 3.0.0'
+depends          'systemd'
 
 supports         'centos', '~> 7.0'

--- a/recipes/mgr.rb
+++ b/recipes/mgr.rb
@@ -15,11 +15,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-systemd_service 'ceph-mgr@' do
-  restart_sec 10
-  start_limit_burst 5
-  override 'ceph-mgr@'
-  drop_in true
+systemd_service_drop_in 'ceph-mgr@' do
+  service_restart_sec 10
+  unit_start_limit_burst 5
+  override 'ceph-mgr@.service'
 end
 
 include_recipe 'osl-ceph'

--- a/spec/unit/recipes/mgr_spec.rb
+++ b/spec/unit/recipes/mgr_spec.rb
@@ -8,12 +8,11 @@ describe 'osl-ceph::mgr' do
         expect { chef_run }.to_not raise_error
       end
       it do
-        expect(chef_run).to create_systemd_service('ceph-mgr@')
+        expect(chef_run).to create_systemd_service_drop_in('ceph-mgr@')
           .with(
-            restart_sec: 10,
-            start_limit_burst: 5,
-            override: 'ceph-mgr@',
-            drop_in: true
+            service_restart_sec: 10,
+            unit_start_limit_burst: 5,
+            override: 'ceph-mgr@.service'
           )
       end
     end


### PR DESCRIPTION
This upgrades this cookbook to use the latest version of the systemd cookbook
and switches to using the ``systemd_service_drop_in`` resource.