### PR TITLE
Implement workaround for mount bug in Chef

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 AllCops:
   TargetChefVersion: 16.latest
-ChefModernize/FoodcriticComments:
+Chef/Modernize/FoodcriticComments:
   Enabled: true
-ChefStyle/CopyrightCommentFormat:
+Chef/Style/CopyrightCommentFormat:
   Enabled: true

--- a/Berksfile
+++ b/Berksfile
@@ -6,6 +6,7 @@ cookbook 'ceph-chef', git: 'git@github.com:osuosl-cookbooks/ceph-chef'
 cookbook 'ceph_test', path: 'test/cookbooks/ceph_test'
 cookbook 'firewall', git: 'git@github.com:osuosl-cookbooks/firewall'
 cookbook 'osl-nrpe', git: 'git@github.com:osuosl-cookbooks/osl-nrpe'
+cookbook 'osl-repos', git: 'git@github.com:osuosl-cookbooks/osl-repos'
 cookbook 'osl-selinux', git: 'git@github.com:osuosl-cookbooks/osl-selinux'
 
 metadata

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-ceph
 # Recipe:: default
 #
-# Copyright:: 2017-2020, Oregon State University
+# Copyright:: 2017-2021, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/mds.rb
+++ b/recipes/mds.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-ceph
 # Recipe:: mds
 #
-# Copyright:: 2018-2020, Oregon State University
+# Copyright:: 2018-2021, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/mgr.rb
+++ b/recipes/mgr.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-ceph
 # Recipe:: mgr
 #
-# Copyright:: 2018-2020, Oregon State University
+# Copyright:: 2018-2021, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/mon.rb
+++ b/recipes/mon.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-ceph
 # Recipe:: mon
 #
-# Copyright:: 2018-2020, Oregon State University
+# Copyright:: 2018-2021, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/monitoring.rb
+++ b/recipes/monitoring.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-ceph
 # Recipe:: monitoring
 #
-# Copyright:: 2018-2020, Oregon State University
+# Copyright:: 2018-2021, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/nagios.rb
+++ b/recipes/nagios.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-ceph
 # Recipe:: nagios
 #
-# Copyright:: 2018-2020, Oregon State University
+# Copyright:: 2018-2021, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/osd.rb
+++ b/recipes/osd.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-ceph
 # Recipe:: osd
 #
-# Copyright:: 2018-2020, Oregon State University
+# Copyright:: 2018-2021, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/osl_cephfs.rb
+++ b/resources/osl_cephfs.rb
@@ -20,7 +20,10 @@ action :mount do
     recursive true
   end
 
-  mons = ceph_chef_mon_addresses.sort.join(',') + ':' + new_resource.subdir
+  # TODO: Workaround https://github.com/chef/chef/issues/10764
+  subdir = new_resource.subdir.match?('^/$') ? '//' : new_resource.subdir
+
+  mons = ceph_chef_mon_addresses.sort.join(',') + ':' + subdir
   mount new_resource.name do
     fstype 'ceph'
     device mons

--- a/spec/unit/resources/osl_cephfs_spec.rb
+++ b/spec/unit/resources/osl_cephfs_spec.rb
@@ -7,8 +7,12 @@ describe 'ceph_test::mds' do
         mon_node = stub_node('mon', p) do |node|
           node.automatic['fqdn'] = 'ceph-mon.example.org'
           node.automatic['roles'] = 'search-ceph-mon'
+          node.automatic['tags'] = %w(ceph-admin ceph-mon ceph-mds)
         end
-        ChefSpec::ServerRunner.new(p.dup.merge(step_into: %w(osl_cephfs))) do |_node, server|
+        ChefSpec::ServerRunner.new(p.dup.merge(step_into: %w(osl_cephfs))) do |node, server|
+          node.automatic['ceph']['mon']['role'] = 'search-ceph-mon'
+          node.automatic['ceph']['network']['public']['cidr'] = %w(10.0.0.0/24)
+          node.automatic['ceph']['network']['cluster']['cidr'] = %w(10.0.0.0/24)
           server.create_node(mon_node)
           server.create_data_bag(
             'ceph',
@@ -50,7 +54,7 @@ describe 'ceph_test::mds' do
         expect(chef_run).to mount_mount('/mnt/ceph')
           .with(
             fstype: 'ceph',
-            device: ':/',
+            device: '10.0.0.2:6789://',
             options: ['_netdev', 'name=cephfs', 'secretfile=/etc/ceph/ceph.client.cephfs.secret'],
             dump: 0,
             pass: 0
@@ -60,7 +64,7 @@ describe 'ceph_test::mds' do
         expect(chef_run).to enable_mount('/mnt/ceph')
           .with(
             fstype: 'ceph',
-            device: ':/',
+            device: '10.0.0.2:6789://',
             options: ['_netdev', 'name=cephfs', 'secretfile=/etc/ceph/ceph.client.cephfs.secret'],
             dump: 0,
             pass: 0
@@ -92,7 +96,7 @@ describe 'ceph_test::mds' do
         expect(chef_run).to mount_mount('/mnt/foo')
           .with(
             fstype: 'ceph',
-            device: ':/foo',
+            device: '10.0.0.2:6789:/foo',
             options: ['_netdev', 'name=cephfs', 'secretfile=/etc/ceph/ceph.client.cephfs.secret'],
             dump: 0,
             pass: 0
@@ -102,7 +106,7 @@ describe 'ceph_test::mds' do
         expect(chef_run).to enable_mount('/mnt/foo')
           .with(
             fstype: 'ceph',
-            device: ':/foo',
+            device: '10.0.0.2:6789:/foo',
             options: ['_netdev', 'name=cephfs', 'secretfile=/etc/ceph/ceph.client.cephfs.secret'],
             dump: 0,
             pass: 0
@@ -134,7 +138,7 @@ describe 'ceph_test::mds' do
         expect(chef_run).to mount_mount('/mnt/bar')
           .with(
             fstype: 'ceph',
-            device: ':/bar',
+            device: '10.0.0.2:6789:/bar',
             options: ['_netdev', 'name=cephfs', 'secretfile=/etc/ceph/ceph.client.cephfs.secret'],
             dump: 0,
             pass: 0
@@ -144,7 +148,7 @@ describe 'ceph_test::mds' do
         expect(chef_run).to enable_mount('/mnt/bar')
           .with(
             fstype: 'ceph',
-            device: ':/bar',
+            device: '10.0.0.2:6789:/bar',
             options: ['_netdev', 'name=cephfs', 'secretfile=/etc/ceph/ceph.client.cephfs.secret'],
             dump: 0,
             pass: 0
@@ -169,7 +173,7 @@ describe 'ceph_test::mds' do
         expect(chef_run).to umount_mount('/mnt/bar')
           .with(
             fstype: 'ceph',
-            device: ':/bar',
+            device: '10.0.0.2:6789:/bar',
             options: ['_netdev', 'name=cephfs', 'secretfile=/etc/ceph/ceph.client.cephfs.secret'],
             dump: 0,
             pass: 0
@@ -179,7 +183,7 @@ describe 'ceph_test::mds' do
         expect(chef_run).to disable_mount('/mnt/bar')
           .with(
             fstype: 'ceph',
-            device: ':/bar',
+            device: '10.0.0.2:6789:/bar',
             options: ['_netdev', 'name=cephfs', 'secretfile=/etc/ceph/ceph.client.cephfs.secret'],
             dump: 0,
             pass: 0


### PR DESCRIPTION
This works around this issue [1] so that mount works properly if we end up using the root mount point with cephfs.

Other changes:

- Cookstyle fixes
- Add osl-repos to Berksfile
- Update ChefSpec to test cephfs with a ceph mon server showing up properly

[1] https://github.com/chef/chef/issues/10764
