### PR TITLE
Move StartLimitBurst to Service

### DIFF
--- a/recipes/mgr.rb
+++ b/recipes/mgr.rb
@@ -20,8 +20,6 @@ osl_systemd_unit_drop_in 'ceph-mgr@' do
   content({
     'Service' => {
       'RestartSec' => 10,
-    },
-    'Unit' => {
       'StartLimitBurst' => 5,
     },
   })

--- a/spec/unit/recipes/mgr_spec.rb
+++ b/spec/unit/recipes/mgr_spec.rb
@@ -14,8 +14,6 @@ describe 'osl-ceph::mgr' do
             content: {
               'Service' => {
                 'RestartSec' => 10,
-              },
-              'Unit' => {
                 'StartLimitBurst' => 5,
               },
             }


### PR DESCRIPTION
On EL7 this is the correct place, however on newer versions of systemd this will need to back to Unit.

Signed-off-by: Lance Albertson <lance@osuosl.org>
