### PR TITLE
multi-node: Switch to using cinder volumes

### DIFF
--- a/provider.tf
+++ b/provider.tf
@@ -4,5 +4,9 @@ terraform {
       source = "terraform-provider-openstack/openstack"
       version = "~> 1.0"
     }
+    null = {
+      source = "hashicorp/null"
+      version = "~> 3.2"
+    }
   }
 }

--- a/test/cookbooks/ceph_test/recipes/multinode_osd.rb
+++ b/test/cookbooks/ceph_test/recipes/multinode_osd.rb
@@ -1,12 +1,14 @@
-# Create fake OSD disks using files
-%w(0 1 2).each do |i|
-  execute "create osd#{i}" do
+# Add OSDs
+%w(
+  sdb
+  sdc
+  sdd
+).each do |d|
+  execute "create osd on #{d}" do
     command <<~EOC
-      dd if=/dev/zero of=/root/osd#{i} bs=1G count=1
-      vgcreate osd#{i} $(losetup --show -f /root/osd#{i})
-      lvcreate -n osd#{i} -l 100%FREE osd#{i}
-      ceph-volume lvm create --bluestore --data osd#{i}/osd#{i}
+      ceph-volume lvm create --bluestore --data /dev/#{d}
+      touch /root/#{d}.done
     EOC
-    not_if "vgs osd#{i}"
+    creates "/root/#{d}.done"
   end
 end


### PR DESCRIPTION
This allows us to test doing reboots and such on a VM and more closely mimics
how this looks on a real system. Using a loopback device is fine with single
nodes, but not for multi nodes.

Signed-off-by: Lance Albertson <lance@osuosl.org>
