### PR TITLE
Update to Nautilus release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # osl-ceph Cookbook
 
-OSL wrapper cookbook for upstream [ceph-chef cookbooks](https://github.com/ceph/ceph-chef/). Also includes support for
-ppc64le compute nodes.
+Cookbook for managing Ceph nodes and clients
 
 ## Supported Platforms
 
-- Ceph Luminous Release
+- Ceph Nautilus Release
 - CentOS 7
+- AlmaLinux 8
 
 # Multi-host test integration
 
@@ -53,10 +53,10 @@ manually. To see what their IP addresses are, just run ``terraform output`` whic
 
 ``` bash
 # You can run the following commands to login to each node
-$ ssh centos@$(terraform output node1)
-$ ssh centos@$(terraform output node2)
-$ ssh centos@$(terraform output node3)
-$ ssh centos@$(terraform output cephfs_client)
+$ ssh centos@$(terraform output -raw node1)
+$ ssh centos@$(terraform output -raw node2)
+$ ssh centos@$(terraform output -raw node3)
+$ ssh centos@$(terraform output -raw cephfs_client)
 
 # Or you can look at the IPs for all for all of the nodes at once
 $ terraform output
@@ -117,12 +117,12 @@ All of these nodes are configured using a Chef Server which is a container runni
 chef-zero server by doing the following:
 
 ``` bash
-$ CHEF_SERVER="$(terraform output chef_zero)" knife node list -c test/chef-config/knife.rb
+$ CHEF_SERVER="$(terraform output -raw chef_zero)" knife node list -c test/chef-config/knife.rb
 cephfs_client
 node1
 node2
 node3
-$ CHEF_SERVER="$(terraform output chef_zero)" knife node edit -c test/chef-config/knife.rb
+$ CHEF_SERVER="$(terraform output -raw chef_zero)" knife node edit -c test/chef-config/knife.rb
 ```
 
 In addition, on any node that has been deployed, you can re-run ``chef-client`` like you normally would on a production

--- a/kitchen.multi-node.yml
+++ b/kitchen.multi-node.yml
@@ -9,9 +9,6 @@ driver:
 transport:
   command_timeout: 3600
 
-platforms:
-  - name: centos-7
-
 verifier:
   name: terraform
   systems:
@@ -56,6 +53,56 @@ verifier:
         - cephfs_client
       hostnames: cephfs_client
 
+platforms:
+  - name: centos-7
+  - name: almalinux-8
+    driver:
+      variables:
+        os_image: "AlmaLinux 8"
+        ssh_user_name: "almalinux"
+    verifier:
+      name: terraform
+      systems:
+        - name: ceph_nodes
+          backend: ssh
+          hosts_output: ceph_nodes
+          sudo: true
+          user: almalinux
+          controls:
+            - ceph_nodes
+          hostnames: ceph_nodes
+        - name: node1
+          backend: ssh
+          hosts_output: node1
+          sudo: true
+          user: almalinux
+          controls:
+            - node1
+          hostnames: node1
+        - name: node2
+          backend: ssh
+          hosts_output: node2
+          sudo: true
+          user: almalinux
+          controls:
+            - node2
+          hostnames: node2
+        - name: node3
+          backend: ssh
+          hosts_output: node3
+          sudo: true
+          user: almalinux
+          controls:
+            - node3
+          hostnames: node3
+        - name: cephfs_client
+          backend: ssh
+          hosts_output: cephfs_client
+          sudo: true
+          user: almalinux
+          controls:
+            - cephfs_client
+          hostnames: cephfs_client
+
 suites:
   - name: multi-node
-    driver: terraform

--- a/main.tf
+++ b/main.tf
@@ -23,7 +23,7 @@ resource "openstack_compute_instance_v2" "chef_zero" {
     key_pair        = var.ssh_key_name
     security_groups = ["default"]
     connection {
-        user = var.ssh_user_name
+        user = "centos"
         host = openstack_networking_port_v2.chef_zero.all_fixed_ips.0
     }
     network {
@@ -204,11 +204,11 @@ resource "openstack_compute_instance_v2" "node3" {
 
 resource "null_resource" "node1" {
     provisioner "local-exec" {
-        command = <<EOF
+        command = <<-EOF
             knife bootstrap -c test/chef-config/knife.rb \
-                centos@${openstack_compute_instance_v2.node1.network.0.fixed_ip_v4} \
+                ${var.ssh_user_name}@${openstack_compute_instance_v2.node1.network.0.fixed_ip_v4} \
                 --bootstrap-version ${var.chef_version} -y -N node1 --sudo \
-                -r 'role[ceph],role[ceph_mon],role[ceph_mgr],role[ceph_osd],role[ceph_mds]'
+                -r 'role[ceph],role[ceph_mon],role[ceph_mgr],role[ceph_osd],role[ceph_mds],recipe[ceph_test::multinode_node1]'
             EOF
         environment = {
             CHEF_SERVER = "${openstack_compute_instance_v2.chef_zero.network.0.fixed_ip_v4}"
@@ -222,9 +222,9 @@ resource "null_resource" "node1" {
 
 resource "null_resource" "node2" {
     provisioner "local-exec" {
-        command = <<EOF
+        command = <<-EOF
             knife bootstrap -c test/chef-config/knife.rb \
-                centos@${openstack_compute_instance_v2.node2.network.0.fixed_ip_v4} \
+                ${var.ssh_user_name}@${openstack_compute_instance_v2.node2.network.0.fixed_ip_v4} \
                 --bootstrap-version ${var.chef_version} -y -N node2 --sudo \
                 -r 'role[ceph],role[ceph_mon],role[ceph_mgr],role[ceph_osd],role[ceph_mds]'
             EOF
@@ -241,9 +241,9 @@ resource "null_resource" "node2" {
 
 resource "null_resource" "node3" {
     provisioner "local-exec" {
-        command = <<EOF
+        command = <<-EOF
             knife bootstrap -c test/chef-config/knife.rb \
-                centos@${openstack_compute_instance_v2.node3.network.0.fixed_ip_v4} \
+                ${var.ssh_user_name}@${openstack_compute_instance_v2.node3.network.0.fixed_ip_v4} \
                 --bootstrap-version ${var.chef_version} -y -N node3 --sudo \
                 -r 'role[ceph],role[ceph_mon],role[ceph_mgr],role[ceph_osd],role[ceph_mds],recipe[ceph_test::multinode_cephfs]'
             EOF
@@ -262,7 +262,7 @@ resource "null_resource" "node3" {
 resource "openstack_compute_instance_v2" "cephfs_client" {
     name            = "cephfs_client"
     image_name      = var.os_image
-    flavor_name     = "m1.small"
+    flavor_name     = "m1.medium"
     key_pair        = var.ssh_key_name
     security_groups = ["default"]
     connection {
@@ -279,9 +279,9 @@ resource "openstack_compute_instance_v2" "cephfs_client" {
         inline = ["echo online"]
     }
     provisioner "local-exec" {
-        command = <<EOF
+        command = <<-EOF
             knife bootstrap -c test/chef-config/knife.rb \
-                centos@${openstack_compute_instance_v2.cephfs_client.network.0.fixed_ip_v4} \
+                ${var.ssh_user_name}@${openstack_compute_instance_v2.cephfs_client.network.0.fixed_ip_v4} \
                 --bootstrap-version ${var.chef_version} -y -N cephfs_client --sudo \
                 -r 'recipe[ceph_test::multinode_client]'
             EOF

--- a/metadata.rb
+++ b/metadata.rb
@@ -14,4 +14,5 @@ depends          'osl-nrpe'
 depends          'osl-repos'
 depends          'osl-resources'
 
+supports         'almalinux', '~> 8.0'
 supports         'centos', '~> 7.0'

--- a/recipes/nagios.rb
+++ b/recipes/nagios.rb
@@ -25,7 +25,7 @@ ceph_nagios = ::File.join(Chef::Config[:file_cache_path], 'ceph-nagios')
 
 git ceph_nagios do
   repository 'https://github.com/osuosl/ceph-nagios-plugins.git'
-  revision 'mimic'
+  revision 'nautilus'
   ignore_failure true
 end
 

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -3,7 +3,7 @@ provides :osl_ceph_install
 default_action :install
 unified_mode true
 
-property :release, String, default: 'mimic'
+property :release, String, default: 'nautilus'
 property :mds, [true, false], default: false
 property :mgr, [true, false], default: false
 property :mon, [true, false], default: false

--- a/resources/mon.rb
+++ b/resources/mon.rb
@@ -27,8 +27,7 @@ action :start do
 
   execute 'create admin keyring' do
     command <<~EOC
-      ceph-authtool --create-keyring #{admin_keyring} \
-        #{admin_key} -n client.admin --set-uid=0 \
+      ceph-authtool --create-keyring #{admin_keyring} #{admin_key} -n client.admin \
         --cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow *' --cap mgr 'allow *'
     EOC
     sensitive true

--- a/resources/test.rb
+++ b/resources/test.rb
@@ -41,6 +41,29 @@ action :start do
 
   osl_ceph_mon 'test'
 
+  # Mute these warnings:
+  #   HEALTH_WARN mon is allowing insecure global_id reclaim
+  # https://docs.ceph.com/en/latest/security/CVE-2021-20288/
+  # TODO: This probably should be removed in octopus
+  execute 'disable global_id warnings' do
+    command <<~EOC
+      ceph config set mon auth_allow_insecure_global_id_reclaim false
+      touch /root/disable_global_id
+    EOC
+    creates '/root/disable_global_id'
+  end
+
+  # Enable v2 network protocol
+  # https://docs.ceph.com/en/latest/rados/configuration/msgr2/#msgr2
+  # TODO: This probably should be removed in octopus
+  execute 'enable msgr2' do
+    command <<~EOC
+      ceph mon enable-msgr2
+      touch /root/enable_msgr2
+    EOC
+    creates '/root/enable_msgr2'
+  end
+
   osl_ceph_mgr 'test'
 
   template '/var/tmp/crush_map_decompressed' do
@@ -89,7 +112,7 @@ action :start do
         puts ''
         loop do
           ceph_health = `ceph -s`
-          break if %r{mds: cephfs-1/1/1 up.*=up:active\}} =~ ceph_health
+          break if /mds: cephfs:.*=up:active\}/ =~ ceph_health
           puts 'Ceph MDS not ready ...'
           sleep(1)
         end

--- a/spec/unit/recipes/nagios_spec.rb
+++ b/spec/unit/recipes/nagios_spec.rb
@@ -11,7 +11,7 @@ describe 'osl-ceph::nagios' do
     is_expected.to sync_git("#{Chef::Config[:file_cache_path]}/ceph-nagios")
       .with(
         repository: 'https://github.com/osuosl/ceph-nagios-plugins.git',
-        revision: 'mimic',
+        revision: 'nautilus',
         ignore_failure: true
       )
   end

--- a/spec/unit/resources/config_spec.rb
+++ b/spec/unit/resources/config_spec.rb
@@ -57,7 +57,7 @@ describe 'osl_ceph_config' do
        public network = 192.168.1.0/24
 
        [mon]
-       keyring = /etc/ceph/$cluster.$name.keyring
+       keyring = /var/lib/ceph/mon/$cluster-$id/keyring
 
        [mds]
        keyring = /var/lib/ceph/mds/$cluster-$id/keyring
@@ -124,7 +124,7 @@ describe 'osl_ceph_config' do
          public network = 192.168.1.0/24,192.168.2.0/24
 
          [mon]
-         keyring = /etc/ceph/$cluster.$name.keyring
+         keyring = /var/lib/ceph/mon/$cluster-$id/keyring
 
          [mds]
          keyring = /var/lib/ceph/mds/$cluster-$id/keyring

--- a/spec/unit/resources/install_spec.rb
+++ b/spec/unit/resources/install_spec.rb
@@ -13,8 +13,8 @@ describe 'osl_ceph_install' do
 
   it do
     is_expected.to create_yum_repository('ceph').with(
-      description: 'Ceph mimic',
-      baseurl: 'https://download.ceph.com/rpm-mimic/el$releasever/$basearch',
+      description: 'Ceph nautilus',
+      baseurl: 'https://download.ceph.com/rpm-nautilus/el$releasever/$basearch',
       gpgkey: 'https://download.ceph.com/keys/release.asc'
     )
   end
@@ -28,8 +28,8 @@ describe 'osl_ceph_install' do
 
     it do
       is_expected.to create_yum_repository('ceph').with(
-        description: 'Ceph mimic',
-        baseurl: 'https://ftp.osuosl.org/pub/osl/repos/yum/$releasever/ceph-mimic/$basearch',
+        description: 'Ceph nautilus',
+        baseurl: 'https://ftp.osuosl.org/pub/osl/repos/yum/$releasever/ceph-nautilus/$basearch',
         gpgkey: 'https://ftp.osuosl.org/pub/osl/repos/yum/RPM-GPG-KEY-osuosl'
       )
     end

--- a/spec/unit/resources/mon_spec.rb
+++ b/spec/unit/resources/mon_spec.rb
@@ -26,7 +26,7 @@ describe 'osl_ceph_mon' do
 
   it do
     is_expected.to run_execute('create admin keyring').with(
-      command: "ceph-authtool --create-keyring /etc/ceph/ceph.client.admin.keyring   --gen-key -n client.admin --set-uid=0   --cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow *' --cap mgr 'allow *'\n",
+      command: "ceph-authtool --create-keyring /etc/ceph/ceph.client.admin.keyring --gen-key -n client.admin   --cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow *' --cap mgr 'allow *'\n",
       sensitive: true,
       creates: '/var/lib/ceph/mon/ceph-Fauxhai/done'
     )
@@ -135,7 +135,7 @@ describe 'osl_ceph_mon' do
 
     it do
       is_expected.to run_execute('create admin keyring').with(
-        command: "ceph-authtool --create-keyring /etc/ceph/ceph.client.admin.keyring   --add-key=AQBkf+Zkw67WNBAAzK7M8SnedPLkYXIanbWNCg== -n client.admin --set-uid=0   --cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow *' --cap mgr 'allow *'\n",
+        command: "ceph-authtool --create-keyring /etc/ceph/ceph.client.admin.keyring --add-key=AQBkf+Zkw67WNBAAzK7M8SnedPLkYXIanbWNCg== -n client.admin   --cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow *' --cap mgr 'allow *'\n",
         sensitive: true,
         creates: '/var/lib/ceph/mon/ceph-Fauxhai/done'
       )

--- a/templates/ceph.conf.erb
+++ b/templates/ceph.conf.erb
@@ -12,7 +12,7 @@ mon pg warn max per osd = 0
 public network = <%= @public_network %>
 
 [mon]
-keyring = /etc/ceph/$cluster.$name.keyring
+keyring = /var/lib/ceph/mon/$cluster-$id/keyring
 
 [mds]
 keyring = /var/lib/ceph/mds/$cluster-$id/keyring

--- a/test/cookbooks/ceph_test/recipes/multinode_cephfs.rb
+++ b/test/cookbooks/ceph_test/recipes/multinode_cephfs.rb
@@ -13,7 +13,7 @@ ruby_block 'wait for ceph mds cluster' do
     puts ''
     loop do
       ceph_health = `ceph -s`
-      break if %r{mds: cephfs-1/1/1 up  \{0=node[0-9]=up:active\}} =~ ceph_health
+      break if /mds: cephfs:.*=up:active\}/ =~ ceph_health
       puts 'Ceph MDS not ready ...'
       sleep(1)
     end

--- a/test/cookbooks/ceph_test/recipes/multinode_network.rb
+++ b/test/cookbooks/ceph_test/recipes/multinode_network.rb
@@ -9,7 +9,7 @@ when 'cephfs-client'
   ip = '10.1.2.20'
 end
 
-secondary_interface = node['network']['default_interface'] == 'eth0' ? 'eth1' : 'ens3'
+secondary_interface = node['network']['default_interface'] == 'eth0' ? 'eth1' : 'ens4'
 
 osl_ifconfig ip do
   onboot 'yes'

--- a/test/cookbooks/ceph_test/recipes/multinode_node1.rb
+++ b/test/cookbooks/ceph_test/recipes/multinode_node1.rb
@@ -1,11 +1,3 @@
-include_recipe 'ceph_test::default'
-
-osl_ceph_install 'mon' do
-  mon true
-end
-
-osl_ceph_mon 'mon'
-
 # Mute these warnings:
 #   HEALTH_WARN mon is allowing insecure global_id reclaim
 # https://docs.ceph.com/en/latest/security/CVE-2021-20288/

--- a/test/integration/default/controls/default_spec.rb
+++ b/test/integration/default/controls/default_spec.rb
@@ -4,13 +4,13 @@ control 'default' do
   %w(ceph-common ceph-selinux).each do |p|
     describe package p do
       it { should be_installed }
-      its('version') { should cmp < '14.0.0' }
+      its('version') { should cmp < '15.0.0' }
     end
   end
 
   describe command('ceph --version') do
     its('exit_status') { should eq 0 }
-    its('stdout') { should include 'mimic' }
+    its('stdout') { should include 'nautilus' }
   end
 
   describe yum.repo('ceph') do

--- a/test/integration/mds/controls/mds.rb
+++ b/test/integration/mds/controls/mds.rb
@@ -1,6 +1,13 @@
+mount_opts =
+  if os.release.to_i >= 8
+    ['rw', 'relatime', 'seclabel', 'name=cephfs', 'secret=<hidden>', 'acl', '_netdev']
+  else
+    ['rw', 'relatime', 'name=cephfs', 'secret=<hidden>', 'acl', 'wsize=16777216']
+  end
+
 control 'mds' do
   describe command('ceph mds stat') do
-    its('stdout') { should match(%(^cephfs-1/1/1 up  {0=node1=up:active}$)) }
+    its('stdout') { should match(%(cephfs:1 {0=node1=up:active})) }
   end
 
   describe command('ss -tpln') do
@@ -28,14 +35,14 @@ control 'mds' do
     it { should be_mounted }
     its('device') { should match '10.1.100.*:/' }
     its('type') { should eq 'ceph' }
-    its('options') { should eq ['rw', 'relatime', 'name=cephfs', 'secret=<hidden>', 'acl', 'wsize=16777216'] }
+    its('options') { should eq mount_opts }
   end
 
   describe mount('/mnt/foo') do
     it { should be_mounted }
     its('device') { should match '10.1.100.*:/foo' }
     its('type') { should eq 'ceph' }
-    its('options') { should eq ['rw', 'relatime', 'name=cephfs', 'secret=<hidden>', 'acl', 'wsize=16777216'] }
+    its('options') { should eq mount_opts }
   end
 
   describe mount('/mnt/bar') do

--- a/test/integration/mon/controls/mon.rb
+++ b/test/integration/mon/controls/mon.rb
@@ -7,6 +7,13 @@ control 'mon' do
     its('stdout') { should match(/mon: 1 daemons, quorum node1/) }
   end
 
+  # v2 msgr2 port
+  describe port('3300') do
+    it { should be_listening }
+    its('processes') { should include 'ceph-mon' }
+  end
+
+  # v1 legacy port
   describe port('6789') do
     it { should be_listening }
     its('processes') { should include 'ceph-mon' }

--- a/test/integration/multi-node/controls/ceph_nodes_spec.rb
+++ b/test/integration/multi-node/controls/ceph_nodes_spec.rb
@@ -1,12 +1,12 @@
 control 'ceph_nodes' do
   describe package('ceph-common') do
     it { should be_installed }
-    its('version') { should cmp < '14.0.0' }
+    its('version') { should cmp < '15.0.0' }
   end
 
   describe command('ceph --version') do
     its('exit_status') { should eq 0 }
-    its('stdout') { should include 'mimic' }
+    its('stdout') { should include 'nautilus' }
   end
 
   describe file('/etc/ceph') do
@@ -26,15 +26,15 @@ control 'ceph_nodes' do
 
   describe command('ceph -s') do
     its('stdout') { should match(/mon: 3 daemons, quorum node[0-9],node[0-9],node[0-9]/) }
-    its('stdout') { should match(/mgr: node[0-9]\(active\), standbys: node[0-9], node[0-9]/) }
+    its('stdout') { should match(/mgr: node[0-9]\(active,.* standbys: node[0-9], node[0-9]/) }
   end
 
   describe command('ceph osd stat') do
-    its('stdout') { should match(/^9 osds: 9 up, 9 in;/) }
+    its('stdout') { should match(/^9 osds: 9 up.* 9 in/) }
   end
 
   describe command('ceph mds stat') do
-    its('stdout') { should match(%(^cephfs-1/1/1 up  {0=node[0-9]=up:active}, 2 up:standby$)) }
+    its('stdout') { should match(/^cephfs:1 {0=node[0-9]=up:active} 2 up:standby$/) }
   end
 
   describe port('6789') do

--- a/test/integration/multi-node/controls/cephfs_spec.rb
+++ b/test/integration/multi-node/controls/cephfs_spec.rb
@@ -1,3 +1,10 @@
+mount_opts =
+  if os.release.to_i >= 8
+    ['rw', 'relatime', 'seclabel', 'name=cephfs', 'secret=<hidden>', 'acl', '_netdev']
+  else
+    ['rw', 'relatime', 'name=cephfs', 'secret=<hidden>', 'acl', 'wsize=16777216']
+  end
+
 control 'cephfs_client' do
   describe file('/etc/ceph/ceph.client.cephfs.secret') do
     its('content') { should match /^AQB3sfxaorsvKhAAkS7kVr01tZQNT1u0mhS1oQ==$/ }
@@ -18,14 +25,14 @@ control 'cephfs_client' do
     it { should be_mounted }
     its('device') { should match '10.1.2.10,10.1.2.11,10.1.2.12:/' }
     its('type') { should eq 'ceph' }
-    its('options') { should eq ['rw', 'relatime', 'name=cephfs', 'secret=<hidden>', 'acl', 'wsize=16777216'] }
+    its('options') { should eq mount_opts }
   end
 
   describe mount('/mnt/foo') do
     it { should be_mounted }
     its('device') { should match '10.1.2.10,10.1.2.11,10.1.2.12:/foo' }
     its('type') { should eq 'ceph' }
-    its('options') { should eq ['rw', 'relatime', 'name=cephfs', 'secret=<hidden>', 'acl', 'wsize=16777216'] }
+    its('options') { should eq mount_opts }
   end
 
   describe mount('/mnt/bar') do

--- a/test/integration/osd/controls/osd.rb
+++ b/test/integration/osd/controls/osd.rb
@@ -1,6 +1,6 @@
 control 'osd' do
   describe command('ceph osd stat') do
-    its('stdout') { should match(/^3 osds: 3 up, 3 in;/) }
+    its('stdout') { should match(/^3 osds: 3 up.*, 3 in/) }
   end
 
   describe command('ss -tpln') do


### PR DESCRIPTION
- Add support for AlmaLinux 8
- Remove `--set-uid` as it's now deprecated
- Disable `global_id` warnings for testing purposes (test-kitchen only)
- Enable `msgr2` so warnings go away (test-kitchen only)
- Fix path to mon keyring
- Update tests to match output with Nautilus

Signed-off-by: Lance Albertson <lance@osuosl.org>
