### PR TITLE
osl_ceph_test: add ipaddress parameter

### DIFF
--- a/resources/test.rb
+++ b/resources/test.rb
@@ -4,9 +4,10 @@ default_action :start
 unified_mode true
 
 property :cephfs, [true, false], default: false
-property :osd_size, String, default: '1G'
 property :config, Hash
 property :create_config, [true, false], default: true
+property :ipaddress, String, default: lazy { node['ipaddress'] }
+property :osd_size, String, default: '1G'
 
 action :start do
   osl_ceph_install 'test' do
@@ -39,7 +40,9 @@ action :start do
     end
   end if new_resource.create_config
 
-  osl_ceph_mon 'test'
+  osl_ceph_mon 'test' do
+    ipaddress new_resource.ipaddress
+  end
 
   # Mute these warnings:
   #   HEALTH_WARN mon is allowing insecure global_id reclaim

--- a/spec/unit/resources/test_spec.rb
+++ b/spec/unit/resources/test_spec.rb
@@ -34,7 +34,7 @@ describe 'osl_ceph_test' do
     )
   end
 
-  it { is_expected.to start_osl_ceph_mon 'test' }
+  it { is_expected.to start_osl_ceph_mon('test').with(ipaddress: '10.0.0.2') }
   it { is_expected.to start_osl_ceph_mgr 'test' }
   it { is_expected.to_not start_osl_ceph_mds 'test' }
   it { is_expected.to create_template('/var/tmp/crush_map_decompressed').with(cookbook: 'osl-ceph') }
@@ -129,5 +129,17 @@ describe 'osl_ceph_test' do
     end
 
     it { is_expected.to_not create_osl_ceph_config('test') }
+  end
+
+  context 'ipaddress' do
+    cached(:subject) { chef_run }
+
+    recipe do
+      osl_ceph_test 'default' do
+        ipaddress '192.168.100.1'
+      end
+    end
+
+    it { is_expected.to start_osl_ceph_mon('test').with(ipaddress: '192.168.100.1') }
   end
 end


### PR DESCRIPTION
Add `ipaddress` parameter which is useful with multi-node openstack testing. Defaults to `node['ipaddress']`.

Signed-off-by: Lance Albertson <lance@osuosl.org>
