### PR TITLE
Also check for fsid in attributes

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -48,7 +48,11 @@ module OslCeph
         begin
           File.read('/etc/ceph/ceph.conf')[/^fsid = (.*)/, 1]
         rescue
-          nil
+          if node['osl-ceph']['config'].empty?
+            nil
+          else
+            node['osl-ceph']['config']['fsid']
+          end
         end
       end
 


### PR DESCRIPTION
This fixes idempotency issues in some situations (i.e. osl-openstack).

Signed-off-by: Lance Albertson <lance@osuosl.org>
