### PR TITLE
Add bootstrap-osd keyring

### DIFF
--- a/recipes/osd.rb
+++ b/recipes/osd.rb
@@ -21,6 +21,14 @@ osl_ceph_install 'osd' do
   osd true
 end
 
+if node['osl-ceph']['data_bag_item']
+  secrets = data_bag_item('ceph', node['osl-ceph']['data_bag_item'])
+
+  osl_ceph_keyring 'bootstrap-osd' do
+    key secrets['bootstrap_key']
+  end
+end
+
 service 'ceph-osd.target' do
   action [:enable, :start]
 end

--- a/spec/unit/recipes/osd_spec.rb
+++ b/spec/unit/recipes/osd_spec.rb
@@ -12,4 +12,18 @@ describe 'osl-ceph::osd' do
   it { is_expected.to install_osl_ceph_install('osd').with(osd: true) }
   it { is_expected.to enable_service 'ceph-osd.target' }
   it { is_expected.to start_service 'ceph-osd.target' }
+  it { is_expected.to_not create_osl_ceph_keyring 'bootstrap-osd' }
+
+  context 'bootstrap-osd set' do
+    cached(:subject) { chef_run }
+    override_attributes['osl-ceph']['data_bag_item'] = 'cluster'
+
+    before do
+      stub_data_bag_item('ceph', 'cluster').and_return(
+        bootstrap_key: 'bootstrap_key'
+      )
+    end
+
+    it { is_expected.to create_osl_ceph_keyring('bootstrap-osd').with(key: 'bootstrap_key') }
+  end
 end


### PR DESCRIPTION
This allows us to recreate OSD's on nodes which was missing in the refactor.
Skip creating it if the bootstrap isn't included in the databag as this can't be
created on an initial run.

Signed-off-by: Lance Albertson <lance@osuosl.org>
