### PR TITLE
Start partprobe on boot before Ceph

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -102,11 +102,13 @@ suites:
         - test/integration/config
         - test/integration/mon
         - test/integration/mgr
+        - test/integration/osd
       controls:
         - default
         - config
         - mon
         - mgr
+        - osd
   - name: radosgw
     run_list:
       - recipe[ceph_test::radosgw]

--- a/test/cookbooks/ceph_test/recipes/osd.rb
+++ b/test/cookbooks/ceph_test/recipes/osd.rb
@@ -1,1 +1,3 @@
 osl_ceph_test 'osd'
+
+include_recipe 'osl-ceph::osd'

--- a/test/integration/osd/controls/osd.rb
+++ b/test/integration/osd/controls/osd.rb
@@ -7,6 +7,16 @@ control 'osd' do
     its('stdout') { should include 'ceph-osd' }
   end
 
+  describe file '/usr/local/libexec/partprobe.sh' do
+    it { should be_executable }
+  end
+
+  describe service 'partprobe.service' do
+    it { should be_installed }
+    it { should be_enabled }
+    it { should be_running }
+  end
+
   describe service('ceph-osd.target') do
     it { should be_installed }
     it { should be_enabled }


### PR DESCRIPTION
Ensure NVMe LV's get scanned for partitions before ceph-osd starts. These DO NOT
get scanned on boot because they are logical volumes and OSDs will fail to start
if they use them.

Also add missing inclusion of OSD tests in the osd suite :facepalm:

Signed-off-by: Lance Albertson <lance@osuosl.org>
