### PR TITLE
Switch to including osl-ceph instead of using osl_ceph_install

### DIFF
--- a/recipes/nagios.rb
+++ b/recipes/nagios.rb
@@ -16,8 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-osl_ceph_install 'nagios'
-
+include_recipe 'osl-ceph'
 include_recipe 'osl-nrpe'
 include_recipe 'osl-git'
 


### PR DESCRIPTION
This will fix an idempotency issue we're seeing on the nagios server.

Signed-off-by: Lance Albertson <lance@osuosl.org>
