### PR TITLE
Switch to using find_resource

### DIFF
--- a/resources/install.rb
+++ b/resources/install.rb
@@ -11,7 +11,7 @@ property :osd, [true, false], default: false
 property :radosgw, [true, false], default: false
 
 action :install do
-  osl_repos_alma 'ceph' do
+  find_resource(:osl_repos_alma, 'default') do
     synergy true
   end
 


### PR DESCRIPTION
This fixes an idempotency issue we were having on nodes that included
osl-apache.

Signed-off-by: Lance Albertson <lance@osuosl.org>
