### PR TITLE
Also check for nvme-1 and nvme-2 paths for partprobe

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,13 +1,7 @@
+source 'https://supermarket.osuosl.org'
 source 'https://supermarket.chef.io'
 
 solver :ruby, :required
-
-cookbook 'osl-git', git: 'git@github.com:osuosl-cookbooks/osl-git'
-cookbook 'osl-firewall', git: 'git@github.com:osuosl-cookbooks/osl-firewall'
-cookbook 'osl-nrpe', git: 'git@github.com:osuosl-cookbooks/osl-nrpe'
-cookbook 'osl-repos', git: 'git@github.com:osuosl-cookbooks/osl-repos'
-cookbook 'osl-resources', git: 'git@github.com:osuosl-cookbooks/osl-resources', branch: 'main'
-cookbook 'osl-selinux', git: 'git@github.com:osuosl-cookbooks/osl-selinux'
 
 cookbook 'ceph_test', path: 'test/cookbooks/ceph_test'
 

--- a/recipes/osd.rb
+++ b/recipes/osd.rb
@@ -27,6 +27,8 @@ file '/usr/local/libexec/partprobe.sh' do
   content <<~EOF
     #!/bin/bash -ex
     [ -d /dev/nvme ] && /usr/sbin/partprobe -s /dev/nvme/* || true
+    [ -d /dev/nvme-1 ] && /usr/sbin/partprobe -s /dev/nvme-1/* || true
+    [ -d /dev/nvme-2 ] && /usr/sbin/partprobe -s /dev/nvme-2/* || true
   EOF
   mode '0750'
 end

--- a/spec/unit/recipes/osd_spec.rb
+++ b/spec/unit/recipes/osd_spec.rb
@@ -19,6 +19,8 @@ describe 'osl-ceph::osd' do
           content: <<~EOF
             #!/bin/bash -ex
             [ -d /dev/nvme ] && /usr/sbin/partprobe -s /dev/nvme/* || true
+            [ -d /dev/nvme-1 ] && /usr/sbin/partprobe -s /dev/nvme-1/* || true
+            [ -d /dev/nvme-2 ] && /usr/sbin/partprobe -s /dev/nvme-2/* || true
           EOF
         )
       end


### PR DESCRIPTION
Some OSD nodes use different names if we have more than one NVMe installed. This
ensures we scan those on boot too.

Also switch to using private supermarket.

Signed-off-by: Lance Albertson <lance@osuosl.org>
