### PR TITLE
Fix ceph-mon mkfs permissions and error handling

### DIFF
--- a/resources/mon.rb
+++ b/resources/mon.rb
@@ -43,13 +43,27 @@ action :start do
     creates "/var/lib/ceph/mon/ceph-#{node['hostname']}/done"
   end
 
+  [
+    admin_keyring,
+    bootstrap_keyring,
+  ].each do |f|
+    file f do
+      owner 'ceph'
+      group 'ceph'
+    end
+  end
+
   execute 'import admin key' do
+    user 'ceph'
+    group 'ceph'
     command "ceph-authtool #{mon_keyring} --import-keyring #{admin_keyring}"
     sensitive true
     creates "/var/lib/ceph/mon/ceph-#{node['hostname']}/done"
   end
 
   execute 'import boostrap-osd key' do
+    user 'ceph'
+    group 'ceph'
     command "ceph-authtool #{mon_keyring} --import-keyring #{bootstrap_keyring}"
     sensitive true
     creates "/var/lib/ceph/mon/ceph-#{node['hostname']}/done"
@@ -76,27 +90,17 @@ action :start do
     only_if { new_resource.generate_monmap }
   end
 
-  [
-    admin_keyring,
-    bootstrap_keyring,
-  ].each do |f|
-    file f do
-      owner 'ceph'
-      group 'ceph'
-    end
-  end
-
   execute 'populate monitor map' do
     user 'ceph'
     group 'ceph'
     if new_resource.generate_monmap
       command <<~EOC
-        ceph-mon --mkfs -i #{node['hostname']} --monmap /etc/ceph/monmap --keyring #{mon_keyring}
+        ceph-mon --mkfs -i #{node['hostname']} --monmap /etc/ceph/monmap --keyring #{mon_keyring} && \
         touch /var/lib/ceph/mon/ceph-#{node['hostname']}/done
       EOC
     else
       command <<~EOC
-        ceph-mon --mkfs -i #{node['hostname']} --keyring #{mon_keyring}
+        ceph-mon --mkfs -i #{node['hostname']} --keyring #{mon_keyring} && \
         touch /var/lib/ceph/mon/ceph-#{node['hostname']}/done
       EOC
     end

--- a/spec/unit/resources/mon_spec.rb
+++ b/spec/unit/resources/mon_spec.rb
@@ -42,6 +42,8 @@ describe 'osl_ceph_mon' do
 
   it do
     is_expected.to run_execute('import admin key').with(
+      user: 'ceph',
+      group: 'ceph',
       command: 'ceph-authtool /var/lib/ceph/ceph.mon.keyring --import-keyring /etc/ceph/ceph.client.admin.keyring',
       sensitive: true,
       creates: '/var/lib/ceph/mon/ceph-Fauxhai/done'
@@ -50,6 +52,8 @@ describe 'osl_ceph_mon' do
 
   it do
     is_expected.to run_execute('import boostrap-osd key').with(
+      user: 'ceph',
+      group: 'ceph',
       command: 'ceph-authtool /var/lib/ceph/ceph.mon.keyring --import-keyring /var/lib/ceph/bootstrap-osd/ceph.keyring',
       sensitive: true,
       creates: '/var/lib/ceph/mon/ceph-Fauxhai/done'
@@ -83,7 +87,7 @@ describe 'osl_ceph_mon' do
     is_expected.to run_execute('populate monitor map').with(
       user: 'ceph',
       group: 'ceph',
-      command: "ceph-mon --mkfs -i Fauxhai --monmap /etc/ceph/monmap --keyring /var/lib/ceph/ceph.mon.keyring\ntouch /var/lib/ceph/mon/ceph-Fauxhai/done\n",
+      command: "ceph-mon --mkfs -i Fauxhai --monmap /etc/ceph/monmap --keyring /var/lib/ceph/ceph.mon.keyring && touch /var/lib/ceph/mon/ceph-Fauxhai/done\n",
       sensitive: true,
       creates: '/var/lib/ceph/mon/ceph-Fauxhai/done'
     )
@@ -153,7 +157,7 @@ describe 'osl_ceph_mon' do
       is_expected.to run_execute('populate monitor map').with(
         user: 'ceph',
         group: 'ceph',
-        command: "ceph-mon --mkfs -i Fauxhai --keyring /var/lib/ceph/ceph.mon.keyring\ntouch /var/lib/ceph/mon/ceph-Fauxhai/done\n",
+        command: "ceph-mon --mkfs -i Fauxhai --keyring /var/lib/ceph/ceph.mon.keyring && touch /var/lib/ceph/mon/ceph-Fauxhai/done\n",
         sensitive: true,
         creates: '/var/lib/ceph/mon/ceph-Fauxhai/done'
       )


### PR DESCRIPTION
- Add user/group 'ceph' to import admin key and bootstrap-osd key
  execute resources so the mon keyring is readable by the ceph user
  during mkfs
- Move file ownership resources for admin and bootstrap-osd keyrings
  before import commands so files are chowned before ceph user reads them
- Chain ceph-mon --mkfs and touch with && so a failed mkfs does not
  create the guard file, allowing Chef to retry on subsequent runs

Signed-off-by: Lance Albertson <lance@osuosl.org>
