### PR TITLE
Update documentation and improve test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,157 +1,73 @@
 # osl-ceph Cookbook
 
-Cookbook for managing Ceph nodes and clients
+Installs and configures [Ceph](https://ceph.io/) nodes and clients at the OSU Open Source Lab. It manages
+the Ceph yum repositories, packages, `ceph.conf`, daemon bootstrapping (mon, mgr, mds, osd, radosgw),
+keyrings, CephFS mounts, RBD mappings and Nagios/NRPE monitoring.
 
-## Supported Platforms
+## Requirements
 
-- Ceph Nautilus Release
-- CentOS 7
-- AlmaLinux 8
+### Platforms
 
-# Multi-host test integration
+- AlmaLinux 8, 9
+- Ceph Reef release (default, configurable via `osl_ceph_install`)
 
-This cookbook utilizes [kitchen-terraform](https://github.com/newcontext-oss/kitchen-terraform) to test deploying
-various parts of this cookbook in multiple nodes, similar to that in production.
+### Chef
 
-## Prereqs
+- Chef 16.0+
 
-- Chef Workstation
-- Terraform
-- `kitchen-terraform`
-- OpenStack cluster
+### Cookbooks
 
-Ensure you have the following in your ``.bashrc`` (or similar):
+- `line`
+- `osl-git`
+- `osl-firewall`
+- `osl-nrpe`
+- `osl-repos`
+- `osl-resources`
 
-``` bash
-export TF_VAR_ssh_key_name="$OS_SSH_KEYPAIR"
-```
+## Attributes
 
-## Supported Deployments
+| Attribute                                                | Default                          | Description                                                              |
+| -------------------------------------------------------- | -------------------------------- | ------------------------------------------------------------------------ |
+| `node['osl-ceph']['config']`                              | `{}`                             | Cluster settings passed to `osl_ceph_config` by the default recipe (`fsid`, `mon_initial_members`, `mon_host`, `public_network`, `cluster_network`, optionally `client_options`, `radosgw`, `rgw_dns_name`, `rgw_dns_s3website_name`). No config is created when empty. |
+| `node['osl-ceph']['data_bag_item']`                       | `nil`                            | Item in the `ceph` data bag containing `mon_key`, `admin_key` and `bootstrap_key`, used by the `mon` and `osd` recipes |
+| `node['osl-ceph']['nrpe']['check_ceph_osd']['critical']`  | `1`                              | Critical threshold for the `check_ceph_osd` Nagios check                 |
 
-- Chef-zero node acting as a Chef Server
-- Three node ceph cluster
-	- Each node ceph node runs mon, mgr, mds and osd services
-- One cephfs client node
-  - The cephfs client node will mount cephfs from the ceph cluster
+## Recipes
+
+| Recipe        | Description                                                                                       |
+| ------------- | ------------------------------------------------------------------------------------------------- |
+| `default`     | Installs the Ceph client packages and creates `ceph.conf` from `node['osl-ceph']['config']`        |
+| `mds`         | Deploys a metadata server (CephFS)                                                                 |
+| `mgr`         | Deploys a manager daemon                                                                           |
+| `mon`         | Deploys a monitor using keys from the `ceph` data bag                                              |
+| `osd`         | Deploys an OSD node, including a partprobe workaround for NVMe logical volumes                     |
+| `radosgw`     | Deploys a RadosGW object gateway                                                                   |
+| `nagios`      | Installs the [ceph-nagios-plugins](https://github.com/osuosl/ceph-nagios-plugins) checks           |
+| `monitoring`  | Configures NRPE checks (`check_ceph_osd`, `check_ceph_mon`) using the `ceph/nagios` data bag item  |
+
+## Resources
+
+| Resource                                                | Description                                              |
+| ------------------------------------------------------- | -------------------------------------------------------- |
+| [osl\_ceph\_install](documentation/osl_ceph_install.md) | Configures Ceph yum repos and installs packages           |
+| [osl\_ceph\_config](documentation/osl_ceph_config.md)   | Manages `/etc/ceph/ceph.conf`                             |
+| [osl\_ceph\_mon](documentation/osl_ceph_mon.md)         | Bootstraps and runs a Ceph monitor                        |
+| [osl\_ceph\_mgr](documentation/osl_ceph_mgr.md)         | Sets up and runs a Ceph manager                           |
+| [osl\_ceph\_mds](documentation/osl_ceph_mds.md)         | Sets up and runs a Ceph metadata server                   |
+| [osl\_ceph\_radosgw](documentation/osl_ceph_radosgw.md) | Sets up and runs a Ceph object gateway                    |
+| [osl\_ceph\_keyring](documentation/osl_ceph_keyring.md) | Writes a keyring file from a known key                    |
+| [osl\_ceph\_client](documentation/osl_ceph_client.md)   | Creates a client auth entity and its keyring/secret file  |
+| [osl\_cephfs](documentation/osl_cephfs.md)              | Mounts a CephFS filesystem                                |
+| [osl\_ceph\_rbdmap](documentation/osl_ceph_rbdmap.md)   | Manages RBD image mappings in `/etc/ceph/rbdmap`          |
+| [osl\_ceph\_test](documentation/osl_ceph_test.md)       | Single-node test cluster (testing only)                   |
+
+`osl_ceph_keyring` and `osl_ceph_client` are also available under their backwards-compatible names
+`ceph_keyring` and `ceph_chef_client`.
 
 ## Testing
 
-First, generate some keys for chef-zero and then simply run the following suite.
-
-``` console
-# Only need to run this once
-$ chef exec rake create_key
-$ kitchen test multi-node
-```
-
-Be patient as this will take a while to converge all of the nodes (approximately 15 minutes).
-
-## Access the nodes
-
-Unfortunately, kitchen-terraform doesn't support using ``kitchen console`` so you will need to log into the nodes
-manually. To see what their IP addresses are, just run ``terraform output`` which will output all of the IPs.
-
-``` bash
-# You can run the following commands to login to each node
-$ ssh centos@$(terraform output -raw node1)
-$ ssh centos@$(terraform output -raw node2)
-$ ssh centos@$(terraform output -raw node3)
-$ ssh centos@$(terraform output -raw cephfs_client)
-
-# Or you can look at the IPs for all for all of the nodes at once
-$ terraform output
-ceph_nodes = [
-    10.1.100.3,
-    10.1.100.66,
-    10.1.100.45
-]
-cephfs_client = 10.1.100.8
-chef_zero = 10.1.100.43
-node1 = 10.1.100.3
-node2 = 10.1.100.66
-node3 = 10.1.100.45
-```
-
-## Running ceph commands
-
-Once you're logged into one of the nodes, you should be able to run the following commands:
-
-``` bash
-$ ceph -s
-  cluster:
-    id:     7964405e-3e4a-4aee-b5a8-bf5e4f816c5d
-    health: HEALTH_OK
-
-  services:
-    mon: 3 daemons, quorum node1,node3,node2
-    mgr: node1(active), standbys: node2, node3
-    mds: cephfs-1/1/1 up  {0=node2=up:active}, 2 up:standby
-    osd: 9 osds: 9 up, 9 in
-
-  data:
-    pools:   2 pools, 256 pgs
-    objects: 24 objects, 32.6KiB
-    usage:   9.04GiB used, 81.0GiB / 90GiB avail
-    pgs:     256 active+clean
-
-$ ceph osd tree
-ID CLASS WEIGHT  TYPE NAME      STATUS REWEIGHT PRI-AFF
--1       0.08817 root default
--3       0.02939     host node1
- 0   hdd 0.00980         osd.0      up  1.00000 1.00000
- 1   hdd 0.00980         osd.1      up  1.00000 1.00000
- 2   hdd 0.00980         osd.2      up  1.00000 1.00000
--5       0.02939     host node2
- 3   hdd 0.00980         osd.3      up  1.00000 1.00000
- 4   hdd 0.00980         osd.4      up  1.00000 1.00000
- 5   hdd 0.00980         osd.5      up  1.00000 1.00000
--7       0.02939     host node3
- 6   hdd 0.00980         osd.6      up  1.00000 1.00000
- 7   hdd 0.00980         osd.7      up  1.00000 1.00000
- 8   hdd 0.00980         osd.8      up  1.00000 1.00000
-```
-
-## Interacting with the chef-zero server
-
-All of these nodes are configured using a Chef Server which is a container running chef-zero. You can interact with the
-chef-zero server by doing the following:
-
-``` bash
-$ CHEF_SERVER="$(terraform output -raw chef_zero)" knife node list -c test/chef-config/knife.rb
-cephfs_client
-node1
-node2
-node3
-$ CHEF_SERVER="$(terraform output -raw chef_zero)" knife node edit -c test/chef-config/knife.rb
-```
-
-In addition, on any node that has been deployed, you can re-run ``chef-client`` like you normally would on a production
-system. This should allow you to do development on your multi-node environment as needed. **Just make sure you include
-the knife config otherwise you will be interacting with our production chef server!**
-
-## Using Terraform directly
-
-You do not need to use kitchen-terraform directly if you're just doing development. It's primarily useful for testing
-the multi-node cluster using inspec. You can simply deploy the cluster using terraform directly by doing the following:
-
-``` bash
-# Sanity check
-$ terraform plan
-# Deploy the cluster
-$ terraform apply
-# Destroy the cluster
-$ terraform destroy
-```
-
-## Cleanup
-
-``` bash
-# To remove all the nodes and start again, run the following test-kitchen command.
-$ kitchen destroy multi-node
-
-# To refresh all the cookbooks, use the following command.
-$ CHEF_SERVER="$(terraform output chef_zero)" chef exec rake knife_upload
-```
+See [TESTING.md](TESTING.md) for unit, single-node and multi-node (kitchen-terraform) testing
+instructions.
 
 ## Contributing
 
@@ -167,7 +83,7 @@ $ CHEF_SERVER="$(terraform output chef_zero)" chef exec rake knife_upload
 - Author:: Oregon State University <chef@osuosl.org>
 
 ```text
-Copyright:: 2017-2019 Oregon State University
+Copyright:: 2017-2026 Oregon State University
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,152 @@
+# Testing
+
+## Unit tests
+
+```console
+chef exec rspec
+```
+
+## Single-node integration tests
+
+Standard Test Kitchen suites using Vagrant (see [kitchen.yml](kitchen.yml)) or OpenStack
+(see [kitchen.openstack.yml](kitchen.openstack.yml)):
+
+```console
+kitchen test default-almalinux-9
+```
+
+Most suites use the `ceph_test` test cookbook ([test/cookbooks/ceph_test](test/cookbooks/ceph_test)),
+which deploys a single-node cluster via the `osl_ceph_test` resource.
+
+## Multi-node integration tests
+
+This cookbook utilizes [kitchen-terraform](https://github.com/newcontext-oss/kitchen-terraform) to test
+deploying various parts of this cookbook on multiple nodes, similar to that in production.
+
+### Prereqs
+
+- Chef Workstation
+- Terraform
+- `kitchen-terraform`
+- OpenStack cluster
+
+Ensure you have the following in your `.bashrc` (or similar):
+
+```bash
+export TF_VAR_ssh_key_name="$OS_SSH_KEYPAIR"
+```
+
+### Supported Deployments
+
+- Chef-zero node acting as a Chef Server
+- Three node ceph cluster
+  - Each ceph node runs mon, mgr, mds and osd services
+- One cephfs client node
+  - The cephfs client node will mount cephfs from the ceph cluster
+
+### Running the tests
+
+First, generate some keys for chef-zero and then simply run the following suite.
+
+```console
+# Only need to run this once
+$ chef exec rake create_key
+$ kitchen test multi-node
+```
+
+Be patient as this will take a while to converge all of the nodes (approximately 15 minutes).
+
+### Access the nodes
+
+Unfortunately, kitchen-terraform doesn't support using `kitchen console` so you will need to log into the
+nodes manually. To see what their IP addresses are, just run `terraform output` which will output all of
+the IPs.
+
+```bash
+# You can run the following commands to login to each node
+$ ssh almalinux@$(terraform output -raw node1)
+$ ssh almalinux@$(terraform output -raw node2)
+$ ssh almalinux@$(terraform output -raw node3)
+$ ssh almalinux@$(terraform output -raw cephfs_client)
+
+# Or you can look at the IPs for all of the nodes at once
+$ terraform output
+ceph_nodes = [
+    10.1.100.3,
+    10.1.100.66,
+    10.1.100.45
+]
+cephfs_client = 10.1.100.8
+chef_zero = 10.1.100.43
+node1 = 10.1.100.3
+node2 = 10.1.100.66
+node3 = 10.1.100.45
+```
+
+### Running ceph commands
+
+Once you're logged into one of the nodes, you should be able to run the following commands:
+
+```bash
+$ ceph -s
+  cluster:
+    id:     7964405e-3e4a-4aee-b5a8-bf5e4f816c5d
+    health: HEALTH_OK
+
+  services:
+    mon: 3 daemons, quorum node1,node3,node2
+    mgr: node1(active), standbys: node2, node3
+    mds: cephfs-1/1/1 up  {0=node2=up:active}, 2 up:standby
+    osd: 9 osds: 9 up, 9 in
+
+$ ceph osd tree
+ID CLASS WEIGHT  TYPE NAME      STATUS REWEIGHT PRI-AFF
+-1       0.08817 root default
+-3       0.02939     host node1
+ 0   hdd 0.00980         osd.0      up  1.00000 1.00000
+...
+```
+
+### Interacting with the chef-zero server
+
+All of these nodes are configured using a Chef Server which is a container running chef-zero. You can
+interact with the chef-zero server by doing the following:
+
+```bash
+$ CHEF_SERVER="$(terraform output -raw chef_zero)" knife node list -c test/chef-config/knife.rb
+cephfs_client
+node1
+node2
+node3
+$ CHEF_SERVER="$(terraform output -raw chef_zero)" knife node edit -c test/chef-config/knife.rb
+```
+
+In addition, on any node that has been deployed, you can re-run `chef-client` like you normally would on a
+production system. This should allow you to do development on your multi-node environment as needed.
+**Just make sure you include the knife config otherwise you will be interacting with our production chef
+server!**
+
+### Using Terraform directly
+
+You do not need to use kitchen-terraform directly if you're just doing development. It's primarily useful
+for testing the multi-node cluster using inspec. You can simply deploy the cluster using terraform
+directly by doing the following:
+
+```bash
+# Sanity check
+$ terraform plan
+# Deploy the cluster
+$ terraform apply
+# Destroy the cluster
+$ terraform destroy
+```
+
+### Cleanup
+
+```bash
+# To remove all the nodes and start again, run the following test-kitchen command.
+$ kitchen destroy multi-node
+
+# To refresh all the cookbooks, use the following command.
+$ CHEF_SERVER="$(terraform output -raw chef_zero)" chef exec rake knife_upload
+```

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,7 +1,3 @@
 default['osl-ceph']['config'] = {}
 default['osl-ceph']['data_bag_item'] = nil
-default['osl-ceph']['nrpe']['check_ceph_df'] = {
-  warning: 80,
-  critical: 90,
-}
 default['osl-ceph']['nrpe']['check_ceph_osd']['critical'] = 1

--- a/documentation/osl_ceph_client.md
+++ b/documentation/osl_ceph_client.md
@@ -1,0 +1,46 @@
+# `osl_ceph_client`
+
+[Back to resource list](../README.md#resources)
+
+Creates a Ceph client auth entity on the cluster (if it does not already exist) and writes its keyring or
+secret file. This resource runs `ceph auth` commands, so it must run on a node with admin access to a
+working cluster.
+
+Also available under the backwards-compatible name `ceph_chef_client`.
+
+## Actions
+
+| Action | Description                                                |
+| ------ | ---------------------------------------------------------- |
+| `:add` | Creates the auth entity and writes the keyring/secret file |
+
+## Properties
+
+| Name         | Type              | Default                                        | Description                                                       |
+| ------------ | ----------------- | ---------------------------------------------- | ----------------------------------------------------------------- |
+| `as_keyring` | `true`, `false`   | `true`                                         | Write a keyring file; if `false`, write only the bare key (secret)|
+| `caps`       | `Hash`            | `{ 'mon' => 'allow r', 'osd' => 'allow r' }`   | Capabilities granted when creating the entity                     |
+| `filename`   | `String`          | `/etc/ceph/ceph.client.<name>.<hostname>.keyring` (or `.secret`) | Destination file                                |
+| `keyname`    | `String`          | `client.<name>.<hostname>`                     | Auth entity name                                                  |
+| `key`        | `String`          | Fetched from the cluster                       | Use this key instead of generating/fetching one (sensitive)       |
+| `owner`      | `String`          | `ceph`                                         | File owner                                                        |
+| `group`      | `String`          | `ceph`                                         | File group                                                        |
+| `mode`       | `Integer`, `String` | `0640`                                       | File mode                                                         |
+
+## Examples
+
+Create a read-only client for the local node:
+
+```ruby
+osl_ceph_client 'glance'
+```
+
+Create a client with custom caps and write it as a bare secret file:
+
+```ruby
+osl_ceph_client 'cinder' do
+  caps('mon' => 'allow r', 'osd' => 'allow rwx pool=cinder')
+  as_keyring false
+  filename '/etc/ceph/ceph.client.cinder.secret'
+end
+```

--- a/documentation/osl_ceph_config.md
+++ b/documentation/osl_ceph_config.md
@@ -1,0 +1,52 @@
+# `osl_ceph_config`
+
+[Back to resource list](../README.md#resources)
+
+Manages `/etc/ceph/ceph.conf`. Other service resources in this cookbook (`osl_ceph_mon`, `osl_ceph_mgr`,
+etc.) can subscribe to this resource to restart their daemons when the configuration changes.
+
+## Actions
+
+| Action    | Description                  |
+| --------- | ---------------------------- |
+| `:create` | Creates `/etc/ceph/ceph.conf`|
+
+## Properties
+
+| Name                     | Type            | Default                                                | Description                                          |
+| ------------------------ | --------------- | ------------------------------------------------------ | ---------------------------------------------------- |
+| `fsid`                   | `String`        | Required                                               | Unique cluster identifier (UUID)                      |
+| `mon_initial_members`    | `Array`         | Required                                               | Hostnames of the initial monitor nodes                |
+| `mon_host`               | `Array`         | Required                                               | IP addresses of the monitor nodes                     |
+| `public_network`         | `Array`         | Required                                               | Public network CIDR(s)                                |
+| `cluster_network`        | `Array`         | Required                                               | Cluster (replication) network CIDR(s)                 |
+| `client_options`         | `Array`         | `['admin socket = /var/run/ceph/$cluster-$type.$id.asok']` | Extra lines for the `[client]` section            |
+| `radosgw`                | `true`, `false` | `false`                                                | Add a `[client.rgw.<hostname>]` section               |
+| `rgw_dns_name`           | `String`        | `node['fqdn']`                                         | `rgw dns name` for the RadosGW section                |
+| `rgw_dns_s3website_name` | `String`        | `<hostname>-website.<domain>`                          | `rgw dns s3website name` for the RadosGW section      |
+
+## Examples
+
+```ruby
+osl_ceph_config 'default' do
+  fsid 'ae3f1d03-bacd-4a90-b869-1a4fabb107f2'
+  mon_initial_members %w(node1 node2 node3)
+  mon_host %w(10.0.0.1 10.0.0.2 10.0.0.3)
+  public_network %w(10.0.0.0/24)
+  cluster_network %w(10.1.0.0/24)
+end
+```
+
+With RadosGW enabled:
+
+```ruby
+osl_ceph_config 'default' do
+  fsid 'ae3f1d03-bacd-4a90-b869-1a4fabb107f2'
+  mon_initial_members %w(node1)
+  mon_host %w(10.0.0.1)
+  public_network %w(10.0.0.0/24)
+  cluster_network %w(10.0.0.0/24)
+  radosgw true
+  rgw_dns_name 'rgw.example.org'
+end
+```

--- a/documentation/osl_ceph_install.md
+++ b/documentation/osl_ceph_install.md
@@ -1,0 +1,44 @@
+# `osl_ceph_install`
+
+[Back to resource list](../README.md#resources)
+
+Installs Ceph packages and configures the upstream (or OSUOSL-mirrored) yum repositories. On ppc64le and
+AlmaLinux 8 nodes the OSUOSL repository mirror is used, otherwise packages come directly from
+`download.ceph.com`. If any of the daemon properties are enabled, the firewall is opened for Ceph traffic
+via `osl_firewall_ceph`.
+
+## Actions
+
+| Action     | Description                                       |
+| ---------- | ------------------------------------------------- |
+| `:install` | Configures the Ceph repos and installs packages   |
+
+## Properties
+
+| Name      | Type            | Default  | Description                                  |
+| --------- | --------------- | -------- | -------------------------------------------- |
+| `release` | `String`        | `reef`   | Ceph release to install                      |
+| `mds`     | `true`, `false` | `false`  | Install the `ceph-mds` package               |
+| `mgr`     | `true`, `false` | `false`  | Install the `ceph-mgr` and dashboard packages|
+| `mon`     | `true`, `false` | `false`  | Install the `ceph-mon` package               |
+| `osd`     | `true`, `false` | `false`  | Install the `ceph-osd` package               |
+| `radosgw` | `true`, `false` | `false`  | Install the `ceph-radosgw` package           |
+
+The `ceph-common` and `ceph-selinux` packages are always installed.
+
+## Examples
+
+Install the Ceph client packages only:
+
+```ruby
+osl_ceph_install 'default'
+```
+
+Install everything needed for a monitor + OSD node:
+
+```ruby
+osl_ceph_install 'default' do
+  mon true
+  osd true
+end
+```

--- a/documentation/osl_ceph_keyring.md
+++ b/documentation/osl_ceph_keyring.md
@@ -1,0 +1,48 @@
+# `osl_ceph_keyring`
+
+[Back to resource list](../README.md#resources)
+
+Manages a Ceph keyring file from a known key, for example one stored in a data bag. Unlike
+[`osl_ceph_client`](osl_ceph_client.md), this resource does not talk to the cluster — it only writes the
+file.
+
+Also available under the backwards-compatible name `ceph_keyring`.
+
+## Actions
+
+| Action    | Description              |
+| --------- | ------------------------ |
+| `:create` | Creates the keyring file |
+| `:delete` | Removes the keyring file |
+
+## Properties
+
+| Name           | Type     | Default                              | Description                                |
+| -------------- | -------- | ------------------------------------ | ------------------------------------------ |
+| `key`          | `String` | Required for `:create`               | The Ceph key (sensitive)                   |
+| `key_name`     | `String` | `client.<name>`                      | Entity name written inside the keyring     |
+| `key_filename` | `String` | `ceph.client.<name>.keyring`         | Filename of the keyring                    |
+| `owner`        | `String` | `ceph`                               | File owner                                 |
+| `group`        | `String` | `ceph`                               | File group                                 |
+| `mode`         | `String` | `0640`                               | File mode                                  |
+| `ceph_dir`     | `String` | `/etc/ceph`                          | Directory the keyring is created in        |
+
+## Examples
+
+Create `/etc/ceph/ceph.client.admin.keyring` for `client.admin`:
+
+```ruby
+osl_ceph_keyring 'admin' do
+  key 'AQBNzhVkbCJDOhAAhpqQqLR9G4y8VBXkCMSWiA=='
+end
+```
+
+Create a bootstrap-osd keyring from a data bag:
+
+```ruby
+secrets = data_bag_item('ceph', 'cluster')
+
+osl_ceph_keyring 'bootstrap-osd' do
+  key secrets['bootstrap_key']
+end
+```

--- a/documentation/osl_ceph_mds.md
+++ b/documentation/osl_ceph_mds.md
@@ -1,0 +1,26 @@
+# `osl_ceph_mds`
+
+[Back to resource list](../README.md#resources)
+
+Sets up a Ceph metadata server (MDS) for CephFS: creates the mds keyring via `ceph auth add` and
+enables/starts the `ceph-mds@<hostname>` service. Requires a working monitor with admin access on the
+node.
+
+## Actions
+
+| Action     | Description                                |
+| ---------- | ------------------------------------------ |
+| `:start`   | Creates the mds keyring, starts the service|
+| `:restart` | Restarts the `ceph-mds@<hostname>` service |
+
+## Properties
+
+None.
+
+## Examples
+
+```ruby
+osl_ceph_mds 'default' do
+  subscribes :restart, 'osl_ceph_config[default]'
+end
+```

--- a/documentation/osl_ceph_mgr.md
+++ b/documentation/osl_ceph_mgr.md
@@ -1,0 +1,25 @@
+# `osl_ceph_mgr`
+
+[Back to resource list](../README.md#resources)
+
+Sets up a Ceph manager daemon: creates the mgr keyring using `ceph auth get-or-create` and enables/starts
+the `ceph-mgr@<hostname>` service. Requires a working monitor with admin access on the node.
+
+## Actions
+
+| Action     | Description                                |
+| ---------- | ------------------------------------------ |
+| `:start`   | Creates the mgr keyring, starts the service|
+| `:restart` | Restarts the `ceph-mgr@<hostname>` service |
+
+## Properties
+
+None.
+
+## Examples
+
+```ruby
+osl_ceph_mgr 'default' do
+  subscribes :restart, 'osl_ceph_config[default]'
+end
+```

--- a/documentation/osl_ceph_mon.md
+++ b/documentation/osl_ceph_mon.md
@@ -1,0 +1,51 @@
+# `osl_ceph_mon`
+
+[Back to resource list](../README.md#resources)
+
+Bootstraps a Ceph monitor: creates the mon, admin and bootstrap-osd keyrings, optionally generates a
+monitor map, runs `ceph-mon --mkfs` and enables/starts the `ceph-mon@<hostname>` service. Keys can either
+be generated on the fly (useful for testing) or passed in explicitly (e.g. from a data bag) so every
+monitor in the cluster shares the same keys.
+
+Requires `/etc/ceph/ceph.conf` to be in place first (see [`osl_ceph_config`](osl_ceph_config.md)).
+
+## Actions
+
+| Action     | Description                                  |
+| ---------- | -------------------------------------------- |
+| `:start`   | Bootstraps the monitor and starts the service|
+| `:restart` | Restarts the `ceph-mon@<hostname>` service   |
+
+## Properties
+
+| Name              | Type            | Default              | Description                                                          |
+| ----------------- | --------------- | -------------------- | -------------------------------------------------------------------- |
+| `mon_key`         | `String`        | Generated            | `mon.` key (sensitive)                                               |
+| `admin_key`       | `String`        | Generated            | `client.admin` key (sensitive)                                       |
+| `bootstrap_key`   | `String`        | Generated            | `client.bootstrap-osd` key (sensitive)                               |
+| `generate_monmap` | `true`, `false` | `true`               | Generate a monmap locally; set to `false` when joining an existing cluster |
+| `ipaddress`       | `String`        | `node['ipaddress']`  | IP address used when generating the monmap                           |
+
+## Examples
+
+Bootstrap a standalone monitor with generated keys (testing):
+
+```ruby
+osl_ceph_mon 'default' do
+  subscribes :restart, 'osl_ceph_config[default]'
+end
+```
+
+Production monitor using shared keys from a data bag:
+
+```ruby
+secrets = data_bag_item('ceph', 'cluster')
+
+osl_ceph_mon 'default' do
+  mon_key secrets['mon_key']
+  admin_key secrets['admin_key']
+  bootstrap_key secrets['bootstrap_key']
+  generate_monmap false
+  subscribes :restart, 'osl_ceph_config[default]'
+end
+```

--- a/documentation/osl_ceph_radosgw.md
+++ b/documentation/osl_ceph_radosgw.md
@@ -1,0 +1,27 @@
+# `osl_ceph_radosgw`
+
+[Back to resource list](../README.md#resources)
+
+Sets up a Ceph object gateway (RadosGW): opens port 8080 in the firewall, creates the rgw keyring via
+`ceph auth add` and enables/starts the `ceph-radosgw@rgw.<hostname>` service. Requires a working monitor
+with admin access on the node and a `[client.rgw.<hostname>]` section in `ceph.conf` (see the `radosgw`
+property on [`osl_ceph_config`](osl_ceph_config.md)).
+
+## Actions
+
+| Action     | Description                                        |
+| ---------- | -------------------------------------------------- |
+| `:start`   | Creates the rgw keyring and starts the service     |
+| `:restart` | Restarts the `ceph-radosgw@rgw.<hostname>` service |
+
+## Properties
+
+None.
+
+## Examples
+
+```ruby
+osl_ceph_radosgw 'default' do
+  subscribes :restart, 'osl_ceph_config[default]'
+end
+```

--- a/documentation/osl_ceph_rbdmap.md
+++ b/documentation/osl_ceph_rbdmap.md
@@ -1,0 +1,44 @@
+# `osl_ceph_rbdmap`
+
+[Back to resource list](../README.md#resources)
+
+Manages RBD image mappings in `/etc/ceph/rbdmap` and enables the `rbdmap` service so images are mapped at
+boot. The keyring for the given `id` is expected at `/etc/ceph/ceph.client.<id>.keyring` (see
+[`osl_ceph_keyring`](osl_ceph_keyring.md)).
+
+## Actions
+
+| Action    | Description                                                  |
+| --------- | ------------------------------------------------------------ |
+| `:create` | Adds the mapping to `/etc/ceph/rbdmap` and enables the service|
+| `:remove` | Removes the mapping from `/etc/ceph/rbdmap`                   |
+
+## Properties
+
+| Name      | Type     | Default                | Description                              |
+| --------- | -------- | ---------------------- | ---------------------------------------- |
+| `image`   | `String` | Name property          | RBD image name                           |
+| `pool`    | `String` | Required               | Pool containing the image                |
+| `id`      | `String` | Required for `:create` | Ceph client id used to map the image     |
+| `options` | `String` | None                   | Extra options appended to the map entry  |
+
+## Examples
+
+Map `data/myimage` using `client.backup`:
+
+```ruby
+osl_ceph_rbdmap 'myimage' do
+  pool 'data'
+  id 'backup'
+end
+```
+
+With extra options:
+
+```ruby
+osl_ceph_rbdmap 'myimage' do
+  pool 'data'
+  id 'backup'
+  options 'lock_on_read,queue_depth=1024'
+end
+```

--- a/documentation/osl_ceph_test.md
+++ b/documentation/osl_ceph_test.md
@@ -1,0 +1,43 @@
+# `osl_ceph_test`
+
+[Back to resource list](../README.md#resources)
+
+Stands up a complete single-node Ceph cluster for **testing only**. It wraps
+[`osl_ceph_install`](osl_ceph_install.md), [`osl_ceph_config`](osl_ceph_config.md),
+[`osl_ceph_mon`](osl_ceph_mon.md) and [`osl_ceph_mgr`](osl_ceph_mgr.md), adjusts the CRUSH map so a single
+node reports healthy, and creates three file-backed loopback OSDs. It can optionally create a CephFS
+filesystem (with MDS) and a RadosGW.
+
+Do not use this resource in production.
+
+## Actions
+
+| Action   | Description                            |
+| -------- | -------------------------------------- |
+| `:start` | Converges the single-node test cluster |
+
+## Properties
+
+| Name            | Type            | Default             | Description                                                       |
+| --------------- | --------------- | ------------------- | ----------------------------------------------------------------- |
+| `cephfs`        | `true`, `false` | `false`             | Also deploy an MDS and create a CephFS filesystem                  |
+| `radosgw`       | `true`, `false` | `false`             | Also deploy a RadosGW                                              |
+| `config`        | `Hash`          | None                | Settings passed to `osl_ceph_config` (fsid, mon_host, ...); a built-in test config is used when omitted |
+| `create_config` | `true`, `false` | `true`              | Set to `false` to skip creating `ceph.conf` entirely               |
+| `ipaddress`     | `String`        | `node['ipaddress']` | IP address for the monitor                                         |
+| `osd_size`      | `String`        | `1G`                | Size of each of the three file-backed OSDs                         |
+
+## Examples
+
+```ruby
+osl_ceph_test 'default'
+```
+
+With CephFS and larger OSDs:
+
+```ruby
+osl_ceph_test 'default' do
+  cephfs true
+  osd_size '4G'
+end
+```

--- a/documentation/osl_cephfs.md
+++ b/documentation/osl_cephfs.md
@@ -1,0 +1,46 @@
+# `osl_cephfs`
+
+[Back to resource list](../README.md#resources)
+
+Mounts a CephFS filesystem. The resource name is the mount point. Writes the client secret to
+`/etc/ceph/ceph.client.<client_name>.secret`, creates the mount point and manages the fstab entry and/or
+mount. Monitor addresses are read from `mon host` in `/etc/ceph/ceph.conf`, so the node needs a Ceph
+config in place (see [`osl_ceph_config`](osl_ceph_config.md)).
+
+## Actions
+
+| Action    | Description                                                  |
+| --------- | ------------------------------------------------------------ |
+| `:mount`  | Adds the fstab entry and mounts the filesystem               |
+| `:enable` | Adds the fstab entry only                                    |
+| `:umount` | Unmounts, removes the fstab entry and deletes the secret file|
+
+## Properties
+
+| Name          | Type     | Default                         | Description                                  |
+| ------------- | -------- | ------------------------------- | -------------------------------------------- |
+| `key`         | `String` | Required for `:enable`, `:mount`| Ceph client key (sensitive)                  |
+| `client_name` | `String` | `admin`                         | Ceph client to authenticate as               |
+| `subdir`      | `String` | `/`                             | CephFS sub-directory to mount                |
+| `options`     | `String` | None                            | Extra mount options                          |
+
+## Examples
+
+Mount the root of CephFS on `/mnt/cephfs` as `client.admin`:
+
+```ruby
+osl_cephfs '/mnt/cephfs' do
+  key 'AQBNzhVkbCJDOhAAhpqQqLR9G4y8VBXkCMSWiA=='
+end
+```
+
+Mount a sub-directory with a dedicated client and read-only options:
+
+```ruby
+osl_cephfs '/mnt/projects' do
+  key data_bag_item('ceph', 'cluster')['projects_key']
+  client_name 'projects'
+  subdir '/projects'
+  options 'ro'
+end
+```

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license          'Apache-2.0'
 chef_version     '>= 16.0'
 issues_url       'https://github.com/osuosl-cookbooks/osl-ceph/issues'
 source_url       'https://github.com/osuosl-cookbooks/osl-ceph'
-description      'Installs/Configures osl-ceph'
+description      'Installs and configures Ceph storage nodes and clients'
 version          '10.1.2'
 
 depends          'line'

--- a/resources/cephfs.rb
+++ b/resources/cephfs.rb
@@ -1,4 +1,3 @@
-resource_name :osl_cephfs
 provides :osl_cephfs
 unified_mode true
 default_action :mount

--- a/resources/client.rb
+++ b/resources/client.rb
@@ -1,4 +1,3 @@
-resource_name :osl_ceph_client
 provides :osl_ceph_client
 # backwards compatible old name
 provides :ceph_chef_client

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -1,4 +1,3 @@
-resource_name :osl_ceph_config
 provides :osl_ceph_config
 default_action :create
 unified_mode true

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -1,4 +1,3 @@
-resource_name :osl_ceph_install
 provides :osl_ceph_install
 default_action :install
 unified_mode true

--- a/resources/keyring.rb
+++ b/resources/keyring.rb
@@ -1,4 +1,3 @@
-resource_name :osl_ceph_keyring
 provides :osl_ceph_keyring
 # backwards compatible old name
 provides :ceph_keyring

--- a/resources/mds.rb
+++ b/resources/mds.rb
@@ -1,4 +1,3 @@
-resource_name :osl_ceph_mds
 provides :osl_ceph_mds
 default_action :start
 unified_mode true

--- a/resources/mgr.rb
+++ b/resources/mgr.rb
@@ -1,5 +1,4 @@
-resource_name :osl_ceph_mon
-provides :osl_ceph_mon
+provides :osl_ceph_mgr
 default_action :start
 unified_mode true
 

--- a/resources/mon.rb
+++ b/resources/mon.rb
@@ -1,4 +1,3 @@
-resource_name :osl_ceph_mon
 provides :osl_ceph_mon
 default_action :start
 unified_mode true

--- a/resources/radosgw.rb
+++ b/resources/radosgw.rb
@@ -1,4 +1,3 @@
-resource_name :osl_ceph_radosgw
 provides :osl_ceph_radosgw
 default_action :start
 unified_mode true

--- a/resources/rbdmap.rb
+++ b/resources/rbdmap.rb
@@ -1,4 +1,3 @@
-resource_name :osl_ceph_rbdmap
 provides :osl_ceph_rbdmap
 default_action :create
 unified_mode true

--- a/resources/test.rb
+++ b/resources/test.rb
@@ -1,4 +1,3 @@
-resource_name :osl_ceph_test
 provides :osl_ceph_test
 default_action :start
 unified_mode true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,8 +6,14 @@ ALMA_8 = {
   version: '8',
 }.freeze
 
+ALMA_9 = {
+  platform: 'almalinux',
+  version: '9',
+}.freeze
+
 ALL_PLATFORMS = [
   ALMA_8,
+  ALMA_9,
 ].freeze
 
 RSpec.configure do |config|

--- a/spec/unit/recipes/radosgw_spec.rb
+++ b/spec/unit/recipes/radosgw_spec.rb
@@ -1,0 +1,19 @@
+require_relative '../../spec_helper'
+
+describe 'osl-ceph::radosgw' do
+  ALL_PLATFORMS.each do |p|
+    context "on #{p[:platform]} #{p[:version]}" do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(p).converge(described_recipe)
+      end
+
+      it 'converges successfully' do
+        expect { chef_run }.to_not raise_error
+      end
+
+      it { is_expected.to include_recipe 'osl-ceph' }
+      it { is_expected.to install_osl_ceph_install('rados').with(radosgw: true) }
+      it { is_expected.to start_osl_ceph_radosgw 'radosgw' }
+    end
+  end
+end

--- a/spec/unit/resources/cephfs_spec.rb
+++ b/spec/unit/resources/cephfs_spec.rb
@@ -137,6 +137,41 @@ describe 'ceph_test::spec_cephfs' do
             pass: 0
           )
       end
+      it do
+        is_expected.to mount_mount('/mnt/options')
+          .with(
+            fstype: 'ceph',
+            device: '10.0.0.2://',
+            options: ['_netdev', 'name=cephfs', 'secretfile=/etc/ceph/ceph.client.cephfs.secret', 'ro'],
+            dump: 0,
+            pass: 0
+          )
+      end
+      it do
+        is_expected.to umount_osl_cephfs('/mnt/umount').with(client_name: 'cephfs')
+      end
+      it do
+        is_expected.to delete_file('ceph.client secret for /mnt/umount')
+          .with(path: '/etc/ceph/ceph.client.cephfs.secret')
+      end
+      it do
+        is_expected.to umount_mount('/mnt/umount')
+          .with(
+            fstype: 'ceph',
+            device: '10.0.0.2:/',
+            dump: 0,
+            pass: 0
+          )
+      end
+      it do
+        is_expected.to disable_mount('/mnt/umount')
+          .with(
+            fstype: 'ceph',
+            device: '10.0.0.2:/',
+            dump: 0,
+            pass: 0
+          )
+      end
     end
   end
 end

--- a/spec/unit/resources/client_spec.rb
+++ b/spec/unit/resources/client_spec.rb
@@ -25,4 +25,50 @@ describe 'osl_ceph_client' do
       sensitive: true
     )
   end
+
+  context 'as_keyring false' do
+    cached(:subject) { chef_run }
+
+    recipe do
+      osl_ceph_client 'test' do
+        key 'foo'
+        as_keyring false
+      end
+    end
+
+    it do
+      is_expected.to create_file('/etc/ceph/ceph.client.test.Fauxhai.secret').with(
+        content: 'foo',
+        owner: 'ceph',
+        group: 'ceph',
+        mode: '0640',
+        sensitive: true
+      )
+    end
+  end
+
+  context 'custom keyname, filename, owner, group and mode' do
+    cached(:subject) { chef_run }
+
+    recipe do
+      osl_ceph_client 'test' do
+        key 'foo'
+        keyname 'client.custom'
+        filename '/etc/ceph/custom.keyring'
+        owner 'nobody'
+        group 'nobody'
+        mode '0600'
+      end
+    end
+
+    it do
+      is_expected.to create_file('/etc/ceph/custom.keyring').with(
+        content: "[client.custom]\n\tkey = foo\n",
+        owner: 'nobody',
+        group: 'nobody',
+        mode: '0600',
+        sensitive: true
+      )
+    end
+  end
 end

--- a/spec/unit/resources/config_spec.rb
+++ b/spec/unit/resources/config_spec.rb
@@ -28,17 +28,17 @@ describe 'osl_ceph_config' do
       owner: 'ceph',
       group: 'ceph',
       variables: {
-          cluster_network: '192.168.1.0/24',
-          client_options: [
-            'admin socket = /var/run/ceph/$cluster-$type.$id.asok',
-          ],
-          fsid: 'e981973a-b299-45c6-a827-db03dd848a8c',
-          mon_host: '192.168.1.100',
-          mon_initial_members: 'node1',
-          public_network: '192.168.1.0/24',
-          radosgw: false,
-          rgw_dns_name: 'fauxhai.local',
-          rgw_dns_s3website_name: 'fauxhai-website.local',
+        cluster_network: '192.168.1.0/24',
+        client_options: [
+          'admin socket = /var/run/ceph/$cluster-$type.$id.asok',
+        ],
+        fsid: 'e981973a-b299-45c6-a827-db03dd848a8c',
+        mon_host: '192.168.1.100',
+        mon_initial_members: 'node1',
+        public_network: '192.168.1.0/24',
+        radosgw: false,
+        rgw_dns_name: 'fauxhai.local',
+        rgw_dns_s3website_name: 'fauxhai-website.local',
       },
       cookbook: 'osl-ceph'
     )
@@ -99,17 +99,17 @@ describe 'osl_ceph_config' do
         owner: 'ceph',
         group: 'ceph',
         variables: {
-            cluster_network: '192.168.1.0/24,192.168.2.0/24',
-            client_options: [
-              'admin socket = /var/run/ceph/guests/$cluster-$type.$id.$pid.$cctid.asok',
-            ],
-            fsid: 'e981973a-b299-45c6-a827-db03dd848a8c',
-            mon_host: '192.168.1.100,192.168.1.101,192.168.1.102',
-            mon_initial_members: 'node1,node2,node3',
-            public_network: '192.168.1.0/24,192.168.2.0/24',
-            radosgw: false,
-            rgw_dns_name: 'fauxhai.local',
-            rgw_dns_s3website_name: 'fauxhai-website.local',
+          cluster_network: '192.168.1.0/24,192.168.2.0/24',
+          client_options: [
+            'admin socket = /var/run/ceph/guests/$cluster-$type.$id.$pid.$cctid.asok',
+          ],
+          fsid: 'e981973a-b299-45c6-a827-db03dd848a8c',
+          mon_host: '192.168.1.100,192.168.1.101,192.168.1.102',
+          mon_initial_members: 'node1,node2,node3',
+          public_network: '192.168.1.0/24,192.168.2.0/24',
+          radosgw: false,
+          rgw_dns_name: 'fauxhai.local',
+          rgw_dns_s3website_name: 'fauxhai-website.local',
         },
         cookbook: 'osl-ceph'
       )
@@ -144,6 +144,66 @@ describe 'osl_ceph_config' do
 
          [client.admin]
          keyring = /etc/ceph/$cluster.client.admin.keyring
+      EOF
+                                                                    )
+    end
+  end
+
+  context 'radosgw' do
+    cached(:subject) { chef_run }
+
+    recipe do
+      osl_ceph_config 'default' do
+        fsid 'e981973a-b299-45c6-a827-db03dd848a8c'
+        mon_initial_members %w(node1)
+        mon_host %w(192.168.1.100)
+        public_network %w(192.168.1.0/24)
+        cluster_network %w(192.168.1.0/24)
+        radosgw true
+        rgw_dns_name 'rgw.example.org'
+        rgw_dns_s3website_name 'rgw-website.example.org'
+      end
+    end
+
+    it do
+      is_expected.to create_template('/etc/ceph/ceph.conf').with(
+        owner: 'ceph',
+        group: 'ceph',
+        variables: {
+          cluster_network: '192.168.1.0/24',
+          client_options: [
+            'admin socket = /var/run/ceph/$cluster-$type.$id.asok',
+          ],
+          fsid: 'e981973a-b299-45c6-a827-db03dd848a8c',
+          mon_host: '192.168.1.100',
+          mon_initial_members: 'node1',
+          public_network: '192.168.1.0/24',
+          radosgw: true,
+          rgw_dns_name: 'rgw.example.org',
+          rgw_dns_s3website_name: 'rgw-website.example.org',
+        },
+        cookbook: 'osl-ceph'
+      )
+    end
+
+    it do
+      is_expected.to render_file('/etc/ceph/ceph.conf').with_content(<<~EOF
+         [client.rgw.Fauxhai]
+         host = Fauxhai
+         keyring = /var/lib/ceph/radosgw/ceph-Fauxhai/keyring
+         rgw cache enabled = true
+         rgw cache lru size = 5000
+         rgw dns name = rgw.example.org
+         rgw dns s3website name = rgw-website.example.org
+         rgw enable ops log = true
+         rgw enable static website = true
+         rgw enable usage log = true
+         rgw expose bucket = true
+         rgw frontends = "beast port=8080"
+         rgw max concurrent requests = 4096
+         rgw num reqs per thread = 500
+         rgw resolve cname = true
+         rgw thread pool size = 512
       EOF
                                                                     )
     end

--- a/spec/unit/resources/install_spec.rb
+++ b/spec/unit/resources/install_spec.rb
@@ -128,6 +128,19 @@ describe 'osl_ceph_install' do
     it { is_expected.to accept_osl_firewall_ceph 'osl-ceph' }
   end
 
+  context 'radosgw' do
+    cached(:subject) { chef_run }
+
+    recipe do
+      osl_ceph_install 'default' do
+        radosgw true
+      end
+    end
+
+    it { is_expected.to install_package(%w(ceph-common ceph-radosgw ceph-selinux)) }
+    it { is_expected.to accept_osl_firewall_ceph 'osl-ceph' }
+  end
+
   context 'all' do
     cached(:subject) { chef_run }
 
@@ -137,10 +150,56 @@ describe 'osl_ceph_install' do
         mgr true
         mon true
         osd true
+        radosgw true
       end
     end
 
-    it { is_expected.to install_package(%w(ceph-common ceph-mds ceph-mgr ceph-mgr-dashboard ceph-mon ceph-osd ceph-selinux)) }
+    it { is_expected.to install_package(%w(ceph-common ceph-mds ceph-mgr ceph-mgr-dashboard ceph-mon ceph-osd ceph-radosgw ceph-selinux)) }
     it { is_expected.to accept_osl_firewall_ceph 'osl-ceph' }
+  end
+
+  context 'release' do
+    cached(:subject) { chef_run }
+
+    recipe do
+      osl_ceph_install 'default' do
+        release 'quincy'
+      end
+    end
+
+    it do
+      is_expected.to create_yum_repository('ceph').with(
+        description: 'Ceph quincy',
+        baseurl: 'https://ftp.osuosl.org/pub/osl/repos/yum/$releasever/ceph-quincy/$basearch',
+        gpgkey: 'https://ftp.osuosl.org/pub/osl/repos/yum/RPM-GPG-KEY-osuosl'
+      )
+    end
+  end
+
+  context 'release almalinux 9' do
+    platform 'almalinux', '9'
+    cached(:subject) { chef_run }
+
+    recipe do
+      osl_ceph_install 'default' do
+        release 'quincy'
+      end
+    end
+
+    it do
+      is_expected.to create_yum_repository('ceph').with(
+        description: 'Ceph quincy',
+        baseurl: 'https://download.ceph.com/rpm-quincy/el$releasever/$basearch',
+        gpgkey: 'https://download.ceph.com/keys/release.asc'
+      )
+    end
+
+    it do
+      is_expected.to create_yum_repository('ceph-noarch').with(
+        description: 'Ceph noarch quincy',
+        baseurl: 'https://download.ceph.com/rpm-quincy/el$releasever/noarch',
+        gpgkey: 'https://download.ceph.com/keys/release.asc'
+      )
+    end
   end
 end

--- a/spec/unit/resources/mds_spec.rb
+++ b/spec/unit/resources/mds_spec.rb
@@ -34,4 +34,16 @@ describe 'osl_ceph_mds' do
 
   it { is_expected.to enable_service('ceph-mds@Fauxhai.service') }
   it { is_expected.to start_service('ceph-mds@Fauxhai.service') }
+
+  context 'restart' do
+    cached(:subject) { chef_run }
+
+    recipe do
+      osl_ceph_mds 'default' do
+        action :restart
+      end
+    end
+
+    it { is_expected.to restart_service('ceph-mds@Fauxhai.service') }
+  end
 end

--- a/spec/unit/resources/mgr_spec.rb
+++ b/spec/unit/resources/mgr_spec.rb
@@ -39,4 +39,16 @@ describe 'osl_ceph_mgr' do
 
   it { is_expected.to enable_service('ceph-mgr@Fauxhai.service') }
   it { is_expected.to start_service('ceph-mgr@Fauxhai.service') }
+
+  context 'restart' do
+    cached(:subject) { chef_run }
+
+    recipe do
+      osl_ceph_mgr 'default' do
+        action :restart
+      end
+    end
+
+    it { is_expected.to restart_service('ceph-mgr@Fauxhai.service') }
+  end
 end

--- a/spec/unit/resources/mon_spec.rb
+++ b/spec/unit/resources/mon_spec.rb
@@ -76,9 +76,9 @@ describe 'osl_ceph_mon' do
   end
 
   %w(
-   /etc/ceph/ceph.client.admin.keyring
-   /var/lib/ceph/bootstrap-osd/ceph.keyring
-   /etc/ceph/monmap
+    /etc/ceph/ceph.client.admin.keyring
+    /var/lib/ceph/bootstrap-osd/ceph.keyring
+    /etc/ceph/monmap
   ).each do |f|
     it { is_expected.to create_file(f).with(owner: 'ceph', group: 'ceph') }
   end
@@ -165,5 +165,17 @@ describe 'osl_ceph_mon' do
 
     it { is_expected.to_not run_execute('generate monitor map') }
     it { is_expected.to_not create_file('/etc/ceph/monmap') }
+  end
+
+  context 'restart' do
+    cached(:subject) { chef_run }
+
+    recipe do
+      osl_ceph_mon 'default' do
+        action :restart
+      end
+    end
+
+    it { is_expected.to restart_service('ceph-mon@Fauxhai.service') }
   end
 end

--- a/spec/unit/resources/radosgw_spec.rb
+++ b/spec/unit/resources/radosgw_spec.rb
@@ -36,3 +36,17 @@ describe 'ceph_test::radosgw' do
     end
   end
 end
+
+describe 'osl_ceph_radosgw restart' do
+  platform 'almalinux', '8'
+  cached(:subject) { chef_run }
+  step_into :osl_ceph_radosgw
+
+  recipe do
+    osl_ceph_radosgw 'default' do
+      action :restart
+    end
+  end
+
+  it { is_expected.to restart_service('ceph-radosgw@rgw.Fauxhai.service') }
+end

--- a/spec/unit/resources/test_spec.rb
+++ b/spec/unit/resources/test_spec.rb
@@ -48,6 +48,20 @@ describe 'osl_ceph_test' do
 
   it { is_expected.to install_package %w(ceph-volume lvm2) }
 
+  it do
+    is_expected.to run_execute('disable global_id warnings').with(
+      command: "ceph config set mon auth_allow_insecure_global_id_reclaim false\ntouch /root/disable_global_id\n",
+      creates: '/root/disable_global_id'
+    )
+  end
+
+  it do
+    is_expected.to run_execute('enable msgr2').with(
+      command: "ceph mon enable-msgr2\ntouch /root/enable_msgr2\n",
+      creates: '/root/enable_msgr2'
+    )
+  end
+
   %w(0 1 2).each do |i|
     it do
       is_expected.to run_execute("create osd#{i}").with(
@@ -77,18 +91,31 @@ describe 'osl_ceph_test' do
     it { is_expected.to run_ruby_block 'wait for ceph mds cluster' }
   end
 
+  context 'radosgw' do
+    cached(:subject) { chef_run }
+
+    recipe do
+      osl_ceph_test 'default' do
+        radosgw true
+      end
+    end
+
+    it { is_expected.to install_osl_ceph_install('test').with(radosgw: true) }
+    it { is_expected.to create_osl_ceph_config('test').with(radosgw: true) }
+  end
+
   context 'config' do
     cached(:subject) { chef_run }
 
     recipe do
       osl_ceph_test 'default' do
         config({
-          'fsid' => '0fdfedf4-553a-405a-b65f-2e9f62bbfc22',
-          'mon_initial_members' => %w(node1),
-          'mon_host' => %w(10.0.0.1),
-          'public_network' => %w(10.0.0.0/24),
-          'cluster_network' => %w(10.0.0.0/24),
-        })
+                 'fsid' => '0fdfedf4-553a-405a-b65f-2e9f62bbfc22',
+                 'mon_initial_members' => %w(node1),
+                 'mon_host' => %w(10.0.0.1),
+                 'public_network' => %w(10.0.0.0/24),
+                 'cluster_network' => %w(10.0.0.0/24),
+               })
       end
     end
 

--- a/test/cookbooks/ceph_test/recipes/spec_cephfs.rb
+++ b/test/cookbooks/ceph_test/recipes/spec_cephfs.rb
@@ -14,3 +14,14 @@ osl_cephfs '/mnt/foo' do
   subdir '/foo'
   client_name 'cephfs'
 end
+
+osl_cephfs '/mnt/options' do
+  key 'AQB3sfxaorsvKhAAkS7kVr01tZQNT1u0mhS1oQ=='
+  client_name 'cephfs'
+  options 'ro'
+end
+
+osl_cephfs '/mnt/umount' do
+  client_name 'cephfs'
+  action :umount
+end

--- a/test/integration/config/controls/config.rb
+++ b/test/integration/config/controls/config.rb
@@ -20,6 +20,7 @@ control 'config' do
     its('global.mon host') { should match /10\.0\.[0-9]+\.[0-9]+/ } if vagrant
     its('global.mon initial members') { should eq 'node1' }
     its('global.public network') { should eq '10.0.0.0/8' }
+    its(['client', 'admin socket']) { should eq '/var/run/ceph/$cluster-$type.$id.asok' }
   end
 
   if keyring

--- a/test/integration/config/inspec.yml
+++ b/test/integration/config/inspec.yml
@@ -2,3 +2,4 @@ name: config
 inputs:
   - name: keyring
     value: false
+version: 0.1.0

--- a/test/integration/default/inspec.yml
+++ b/test/integration/default/inspec.yml
@@ -2,3 +2,4 @@ name: default
 inputs:
   - name: firewall
     value: true
+version: 0.1.0

--- a/test/integration/mds/inspec.yml
+++ b/test/integration/mds/inspec.yml
@@ -1,1 +1,2 @@
 name: mds
+version: 0.1.0

--- a/test/integration/mgr/inspec.yml
+++ b/test/integration/mgr/inspec.yml
@@ -1,1 +1,2 @@
 name: mgr
+version: 0.1.0

--- a/test/integration/mon/inspec.yml
+++ b/test/integration/mon/inspec.yml
@@ -1,1 +1,2 @@
 name: mon
+version: 0.1.0

--- a/test/integration/mon_keys/inspec.yml
+++ b/test/integration/mon_keys/inspec.yml
@@ -1,1 +1,2 @@
 name: mon_keys
+version: 0.1.0

--- a/test/integration/monitoring/controls/monitoring.rb
+++ b/test/integration/monitoring/controls/monitoring.rb
@@ -1,17 +1,29 @@
-%w(
-  check_ceph_mon
-  check_ceph_osd
-  check_ceph_rgw
-).each do |check|
-  describe command("/usr/lib64/nagios/plugins/check_nrpe -H 127.0.0.1 -c #{check}") do
+control 'monitoring' do
+  describe file('/etc/ceph/ceph.client.nagios.keyring') do
+    its('owner') { should eq 'nrpe' }
+    its('group') { should eq 'nrpe' }
+    its('mode') { should cmp '0640' }
+    its('content') { should match(/^\[client\.nagios\]$/) }
+  end
+
+  describe etc_group.where(name: 'ceph') do
+    its('users') { should include 'nrpe' }
+  end
+
+  %w(
+    check_ceph_mon
+    check_ceph_osd
+  ).each do |check|
+    describe command("/usr/lib64/nagios/plugins/check_nrpe -H 127.0.0.1 -c #{check}") do
+      its('exit_status') { should eq 0 }
+    end
+  end
+
+  describe command('/usr/lib64/nagios/plugins/check_ceph_df -W 80 -C 90') do
     its('exit_status') { should eq 0 }
   end
-end
 
-describe command('/usr/lib64/nagios/plugins/check_ceph_df -W 80 -C 90') do
-  its('exit_status') { should eq 0 }
-end
-
-describe command('/usr/lib64/nagios/plugins/check_ceph_health') do
-  its('exit_status') { should eq 0 }
+  describe command('/usr/lib64/nagios/plugins/check_ceph_health') do
+    its('exit_status') { should eq 0 }
+  end
 end

--- a/test/integration/monitoring/inspec.yml
+++ b/test/integration/monitoring/inspec.yml
@@ -1,1 +1,2 @@
 name: monitoring
+version: 0.1.0

--- a/test/integration/multi-node/inspec.yml
+++ b/test/integration/multi-node/inspec.yml
@@ -1,2 +1,3 @@
 ---
 name: default
+version: 0.1.0

--- a/test/integration/nagios/inspec.yml
+++ b/test/integration/nagios/inspec.yml
@@ -1,1 +1,2 @@
 name: nagios
+version: 0.1.0

--- a/test/integration/osd/inspec.yml
+++ b/test/integration/osd/inspec.yml
@@ -1,1 +1,2 @@
 name: osd
+version: 0.1.0

--- a/test/integration/radosgw/controls/radosgw.rb
+++ b/test/integration/radosgw/controls/radosgw.rb
@@ -7,6 +7,17 @@ control 'radosgw' do
     it { should be_installed }
   end
 
+  describe ini '/etc/ceph/ceph.conf' do
+    its(['client.rgw.node1', 'host']) { should eq 'node1' }
+    its(['client.rgw.node1', 'keyring']) { should eq '/var/lib/ceph/radosgw/ceph-node1/keyring' }
+    its(['client.rgw.node1', 'rgw frontends']) { should eq '"beast port=8080"' }
+  end
+
+  describe file('/etc/ceph/ceph.rgw.node1.keyring') do
+    it { should be_symlink }
+    its('link_path') { should eq '/var/lib/ceph/radosgw/ceph-node1/keyring' }
+  end
+
   describe port 8080 do
     it { should be_listening }
     its('processes') { should include 'notif-worker0' }

--- a/test/integration/radosgw/inspec.yml
+++ b/test/integration/radosgw/inspec.yml
@@ -1,1 +1,2 @@
 name: radosgw
+version: 0.1.0

--- a/test/integration/rbdmap/controls/rbdmap_spec.rb
+++ b/test/integration/rbdmap/controls/rbdmap_spec.rb
@@ -2,6 +2,7 @@ control 'rbdmap' do
   describe file '/etc/ceph/rbdmap' do
     its('content') { should match %r{^pool/image id=image,keyring=/etc/ceph/ceph\.client\.image\.keyring$} }
     its('content') { should match %r{^pool/image_with_options id=image,keyring=/etc/ceph/ceph\.client\.image\.keyring,options=queue_depth=64$} }
+    its('content') { should_not match %r{^pool/delete} }
   end
 
   describe service 'rbdmap' do

--- a/test/integration/rbdmap/inspec.yml
+++ b/test/integration/rbdmap/inspec.yml
@@ -1,1 +1,2 @@
 name: rbdmap
+version: 0.1.0


### PR DESCRIPTION
Refresh all docs to the current cookbook state and fill unit and
integration test gaps.

Documentation:
- Rewrite README for AlmaLinux 8/9 and Ceph Reef
- Add per-resource docs under documentation/
- Move multi-node terraform docs to TESTING.md

Fixes:
- Fix osl_ceph_mgr providing :osl_ceph_mon
- Remove unused check_ceph_df attribute
- Drop redundant resource_name declarations
- Improve metadata description

Unit tests:
- Add missing radosgw recipe spec
- Cover :restart and :umount actions
- Cover radosgw, release, options and client keyring properties
- Add AlmaLinux 9 to test platforms

InSpec tests:
- Wrap monitoring tests in a control block so they actually run
- Remove check_ceph_rgw nrpe test with no NRPE command defined
- Verify nagios keyring, rbdmap :remove and radosgw ceph.conf section
- Add missing version field to inspec profiles

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Signed-off-by: Lance Albertson <lance@osuosl.org>
