### PR TITLE
Add s3_admin recipe for admin-driven S3 bucket provisioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,11 @@ keyrings, CephFS mounts, RBD mappings and Nagios/NRPE monitoring.
 | Attribute                                                | Default                          | Description                                                              |
 | -------------------------------------------------------- | -------------------------------- | ------------------------------------------------------------------------ |
 | `node['osl-ceph']['config']`                              | `{}`                             | Cluster settings passed to `osl_ceph_config` by the default recipe (`fsid`, `mon_initial_members`, `mon_host`, `public_network`, `cluster_network`, optionally `client_options`, `radosgw`, `rgw_dns_name`, `rgw_dns_s3website_name`). No config is created when empty. |
-| `node['osl-ceph']['data_bag_item']`                       | `nil`                            | Item in the `ceph` data bag containing `mon_key`, `admin_key` and `bootstrap_key`, used by the `mon` and `osd` recipes |
+| `node['osl-ceph']['data_bag_item']`                       | `nil`                            | Item in the `ceph` data bag containing `mon_key`, `admin_key` and `bootstrap_key` (and optionally `rgw_admin_access_key`/`rgw_admin_secret_key`), used by the `mon`, `osd` and `s3_admin` recipes |
 | `node['osl-ceph']['nrpe']['check_ceph_osd']['critical']`  | `1`                              | Critical threshold for the `check_ceph_osd` Nagios check                 |
+| `node['osl-ceph']['s3']['host_base']`                     | `s3.osuosl.org`                  | S3 endpoint written to the admin `/root/.s3cfg` by the `s3_admin` recipe |
+| `node['osl-ceph']['s3']['host_bucket']`                   | `nil`                            | `host_bucket` for `/root/.s3cfg`; defaults to `%(bucket)s.<host_base>` when unset |
+| `node['osl-ceph']['s3']['use_https']`                     | `true`                           | Whether s3cmd should use HTTPS to talk to the S3 endpoint                |
 
 ## Recipes
 
@@ -42,6 +45,7 @@ keyrings, CephFS mounts, RBD mappings and Nagios/NRPE monitoring.
 | `mon`         | Deploys a monitor using keys from the `ceph` data bag                                              |
 | `osd`         | Deploys an OSD node, including a partprobe workaround for NVMe logical volumes                     |
 | `radosgw`     | Deploys a RadosGW object gateway                                                                   |
+| `s3_admin`    | Deploys the admin s3cmd config (`/root/.s3cfg`) and the `create-s3-bucket` provisioning script on mon hosts, using the `rgw_admin_access_key`/`rgw_admin_secret_key` fields from the `ceph` data bag item |
 | `nagios`      | Installs the [ceph-nagios-plugins](https://github.com/osuosl/ceph-nagios-plugins) checks           |
 | `monitoring`  | Configures NRPE checks (`check_ceph_osd`, `check_ceph_mon`) using the `ceph/nagios` data bag item  |
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,3 +1,7 @@
 default['osl-ceph']['config'] = {}
 default['osl-ceph']['data_bag_item'] = nil
 default['osl-ceph']['nrpe']['check_ceph_osd']['critical'] = 1
+default['osl-ceph']['s3']['host_base'] = 's3.osuosl.org'
+# Defaults to %(bucket)s.<host_base> when nil
+default['osl-ceph']['s3']['host_bucket'] = nil
+default['osl-ceph']['s3']['use_https'] = true

--- a/files/create-s3-bucket
+++ b/files/create-s3-bucket
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Provision an S3 bucket for a project: create the RGW user if needed,
+# create the bucket as the admin user, then transfer ownership.
+#
+# Managed by Chef (osl-ceph::s3_admin) -- local changes will be overwritten.
+set -euo pipefail
+
+usage() {
+  cat >&2 <<EOF
+Usage: ${0##*/} <project> <bucket>
+
+Creates the bucket <project>-<bucket> owned by the RGW user <project>.
+Example: ${0##*/} fooproject backups   # creates fooproject-backups
+EOF
+  exit 2
+}
+
+[[ $# -eq 2 ]] || usage
+
+project=$1
+bucket=$2
+
+# Both parts must be valid S3 name components so the constructed
+# <project>-<bucket> name always matches the naming scheme.
+name_re='^[a-z0-9]([a-z0-9-]*[a-z0-9])?$'
+for part in "$project" "$bucket"; do
+  if ! [[ $part =~ $name_re ]]; then
+    echo "error: '$part' must be lowercase alphanumeric (dashes allowed inside)" >&2
+    exit 1
+  fi
+done
+
+full_bucket="${project}-${bucket}"
+
+bucket_owner() {
+  radosgw-admin bucket stats --bucket="$full_bucket" 2>/dev/null \
+    | grep -oP '"owner"\s*:\s*"\K[^"]*' | head -n1
+}
+
+if ! radosgw-admin user info --uid="$project" > /dev/null 2>&1; then
+  echo "Creating RGW user '$project'"
+  radosgw-admin user create --uid="$project" --display-name="$project" > /dev/null
+fi
+
+owner=$(bucket_owner || true)
+if [[ -z $owner ]]; then
+  echo "Creating bucket '$full_bucket'"
+  s3cmd --config /root/.s3cfg mb "s3://$full_bucket" > /dev/null
+elif [[ $owner != "$project" && $owner != admin ]]; then
+  echo "error: bucket '$full_bucket' already exists and is owned by '$owner', refusing to take it over" >&2
+  exit 1
+else
+  echo "Bucket '$full_bucket' already exists (owner: $owner)"
+fi
+
+radosgw-admin bucket link --bucket="$full_bucket" --uid="$project"
+radosgw-admin bucket chown --bucket="$full_bucket" --uid="$project" > /dev/null
+
+owner=$(bucket_owner || true)
+if [[ $owner != "$project" ]]; then
+  echo "error: bucket '$full_bucket' is owned by '${owner:-<unknown>}', expected '$project'" >&2
+  exit 1
+fi
+
+echo "Bucket '$full_bucket' is owned by '$project'"
+echo
+echo "Credentials for project '$project':"
+radosgw-admin user info --uid="$project" | grep -E '"(access_key|secret_key)"'
+echo
+echo "Deliver these keys via the Secrets app on https://cloud.osuosl.org -- never by email or chat."

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -135,6 +135,26 @@ suites:
         - mon
         - mgr
         - radosgw
+  - name: s3_admin
+    run_list:
+      - recipe[ceph_test::s3_admin]
+    attributes:
+      osl-ceph:
+        data_bag_item: cluster
+    verifier:
+      inspec_tests:
+        - test/integration/default
+        - test/integration/config
+        - test/integration/mon
+        - test/integration/mgr
+        - test/integration/radosgw
+      controls:
+        - default
+        - config
+        - mon
+        - mgr
+        - radosgw
+        - s3_admin
   - name: monitoring
     run_list:
       - recipe[ceph_test::mds]

--- a/recipes/s3_admin.rb
+++ b/recipes/s3_admin.rb
@@ -1,0 +1,49 @@
+#
+# Cookbook:: osl-ceph
+# Recipe:: s3_admin
+#
+# Copyright:: 2026, Oregon State University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+if node['osl-ceph']['data_bag_item']
+  secrets = data_bag_item('ceph', node['osl-ceph']['data_bag_item'])
+
+  if secrets['rgw_admin_access_key'] && secrets['rgw_admin_secret_key']
+    include_recipe 'osl-repos::epel'
+
+    package 's3cmd'
+
+    s3 = node['osl-ceph']['s3']
+
+    template '/root/.s3cfg' do
+      source 's3cfg.erb'
+      owner 'root'
+      group 'root'
+      mode '0600'
+      sensitive true
+      variables(
+        access_key: secrets['rgw_admin_access_key'],
+        secret_key: secrets['rgw_admin_secret_key'],
+        host_base: s3['host_base'],
+        host_bucket: s3['host_bucket'] || "%(bucket)s.#{s3['host_base']}",
+        use_https: s3['use_https']
+      )
+    end
+
+    cookbook_file '/usr/local/sbin/create-s3-bucket' do
+      owner 'root'
+      group 'root'
+      mode '0750'
+    end
+  end
+end

--- a/spec/unit/recipes/s3_admin_spec.rb
+++ b/spec/unit/recipes/s3_admin_spec.rb
@@ -1,0 +1,110 @@
+require_relative '../../spec_helper'
+
+describe 'osl-ceph::s3_admin' do
+  ALL_PLATFORMS.each do |p|
+    context "on #{p[:platform]} #{p[:version]}" do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(p).converge(described_recipe)
+      end
+
+      it 'converges successfully' do
+        expect { chef_run }.to_not raise_error
+      end
+
+      it { is_expected.to_not install_package 's3cmd' }
+      it { is_expected.to_not create_template '/root/.s3cfg' }
+      it { is_expected.to_not create_cookbook_file '/usr/local/sbin/create-s3-bucket' }
+
+      context 'cluster defined without rgw admin keys' do
+        cached(:chef_run) do
+          ChefSpec::SoloRunner.new(p) do |node|
+            node.normal['osl-ceph']['data_bag_item'] = 'cluster'
+          end.converge(described_recipe)
+        end
+
+        before do
+          stub_data_bag_item('ceph', 'cluster').and_return(
+            'mon_key' => 'mon_key',
+            'admin_key' => 'admin_key',
+            'bootstrap_key' => 'bootstrap_key'
+          )
+        end
+
+        it { is_expected.to_not install_package 's3cmd' }
+        it { is_expected.to_not create_template '/root/.s3cfg' }
+        it { is_expected.to_not create_cookbook_file '/usr/local/sbin/create-s3-bucket' }
+      end
+
+      context 'cluster defined with rgw admin keys' do
+        cached(:chef_run) do
+          ChefSpec::SoloRunner.new(p) do |node|
+            node.normal['osl-ceph']['data_bag_item'] = 'cluster'
+          end.converge(described_recipe)
+        end
+
+        before do
+          stub_data_bag_item('ceph', 'cluster').and_return(
+            'mon_key' => 'mon_key',
+            'admin_key' => 'admin_key',
+            'bootstrap_key' => 'bootstrap_key',
+            'rgw_admin_access_key' => 'TESTACCESSKEY',
+            'rgw_admin_secret_key' => 'TESTSECRETKEY'
+          )
+        end
+
+        it { is_expected.to include_recipe 'osl-repos::epel' }
+        it { is_expected.to install_package 's3cmd' }
+
+        it do
+          is_expected.to create_template('/root/.s3cfg').with(
+            owner: 'root',
+            group: 'root',
+            mode: '0600',
+            sensitive: true
+          )
+        end
+
+        it do
+          is_expected.to render_file('/root/.s3cfg').with_content(<<~EOF)
+            [default]
+            access_key = TESTACCESSKEY
+            secret_key = TESTSECRETKEY
+            host_base = s3.osuosl.org
+            host_bucket = %(bucket)s.s3.osuosl.org
+            use_https = True
+          EOF
+        end
+
+        it do
+          is_expected.to create_cookbook_file('/usr/local/sbin/create-s3-bucket').with(
+            owner: 'root',
+            group: 'root',
+            mode: '0750'
+          )
+        end
+
+        context 'with a custom endpoint' do
+          cached(:chef_run) do
+            ChefSpec::SoloRunner.new(p) do |node|
+              node.normal['osl-ceph']['data_bag_item'] = 'cluster'
+              node.normal['osl-ceph']['s3']['host_base'] = 'localhost:8080'
+              node.normal['osl-ceph']['s3']['host_bucket'] = 'localhost:8080'
+              node.normal['osl-ceph']['s3']['use_https'] = false
+            end.converge(described_recipe)
+          end
+
+          it do
+            is_expected.to render_file('/root/.s3cfg').with_content(<<~EOF)
+              [default]
+              access_key = TESTACCESSKEY
+              secret_key = TESTSECRETKEY
+              host_base = localhost:8080
+              host_bucket = localhost:8080
+              use_https = False
+            EOF
+          end
+        end
+      end
+    end
+  end
+end

--- a/templates/s3cfg.erb
+++ b/templates/s3cfg.erb
@@ -1,0 +1,6 @@
+[default]
+access_key = <%= @access_key %>
+secret_key = <%= @secret_key %>
+host_base = <%= @host_base %>
+host_bucket = <%= @host_bucket %>
+use_https = <%= @use_https ? 'True' : 'False' %>

--- a/test/cookbooks/ceph_test/recipes/s3_admin.rb
+++ b/test/cookbooks/ceph_test/recipes/s3_admin.rb
@@ -1,0 +1,17 @@
+include_recipe 'ceph_test::radosgw'
+
+# The admin RGW user is created manually in production; create it here with
+# the keys from the test data bag so create-s3-bucket can authenticate.
+execute 'create admin rgw user' do
+  command 'radosgw-admin user create --uid=admin --display-name="OSL Admin" ' \
+          '--access-key TESTACCESSKEY --secret-key TESTSECRETKEY'
+  not_if 'radosgw-admin user info --uid=admin'
+end
+
+# Point s3cmd at the local RGW. The endpoint must match rgw_dns_name (the
+# node fqdn) or RGW misparses path-style requests as virtual-host style.
+node.override['osl-ceph']['s3']['host_base'] = "#{node['fqdn']}:8080"
+node.override['osl-ceph']['s3']['host_bucket'] = "#{node['fqdn']}:8080"
+node.override['osl-ceph']['s3']['use_https'] = false
+
+include_recipe 'osl-ceph::s3_admin'

--- a/test/integration/data_bags/ceph/cluster.json
+++ b/test/integration/data_bags/ceph/cluster.json
@@ -2,5 +2,7 @@
   "id": "cluster",
   "mon_key": "AQBkf+ZkFIMSLxAAnYRXnc/CaUdHChGCxyH3IQ==",
   "admin_key": "AQBkf+Zkw67WNBAAzK7M8SnedPLkYXIanbWNCg==",
-  "bootstrap_key": "AQBkf+Zk+GsrOxAA1xYwZeLRB5gLI42lmjGV+A=="
+  "bootstrap_key": "AQBkf+Zk+GsrOxAA1xYwZeLRB5gLI42lmjGV+A==",
+  "rgw_admin_access_key": "TESTACCESSKEY",
+  "rgw_admin_secret_key": "TESTSECRETKEY"
 }

--- a/test/integration/radosgw/controls/radosgw.rb
+++ b/test/integration/radosgw/controls/radosgw.rb
@@ -20,7 +20,7 @@ control 'radosgw' do
 
   describe port 8080 do
     it { should be_listening }
-    its('processes') { should include 'notif-worker0' }
+    its('processes') { should include('radosgw').or include('notif-worker0') }
   end
 
   %w(ceph-radosgw@rgw.node1.service ceph-radosgw.target).each do |s|

--- a/test/integration/s3_admin/controls/s3_admin.rb
+++ b/test/integration/s3_admin/controls/s3_admin.rb
@@ -1,0 +1,56 @@
+# The s3_admin kitchen suite points the S3 endpoint at the local RGW
+# (<fqdn>:8080, no https) so create-s3-bucket can be exercised end-to-end.
+control 's3_admin' do
+  fqdn = command('hostname -f').stdout.strip
+  describe package('s3cmd') do
+    it { should be_installed }
+  end
+
+  describe file('/root/.s3cfg') do
+    it { should be_file }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+    its('mode') { should cmp '0600' }
+    its('content') { should match(/^access_key = TESTACCESSKEY$/) }
+    its('content') { should match(/^secret_key = TESTSECRETKEY$/) }
+    its('content') { should match(/^host_base = #{Regexp.escape(fqdn)}:8080$/) }
+    its('content') { should match(/^host_bucket = #{Regexp.escape(fqdn)}:8080$/) }
+    its('content') { should match(/^use_https = False$/) }
+  end
+
+  describe file('/usr/local/sbin/create-s3-bucket') do
+    it { should be_file }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+    its('mode') { should cmp '0750' }
+  end
+
+  describe command('/usr/local/sbin/create-s3-bucket') do
+    its('exit_status') { should eq 2 }
+    its('stderr') { should match(/^Usage:/) }
+  end
+
+  describe command('/usr/local/sbin/create-s3-bucket foo_bad backups') do
+    its('exit_status') { should eq 1 }
+    its('stderr') { should match(/must be lowercase alphanumeric/) }
+  end
+
+  describe command('/usr/local/sbin/create-s3-bucket fooproject backups') do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should match(/Bucket 'fooproject-backups' is owned by 'fooproject'/) }
+    its('stdout') { should match(/"access_key"/) }
+    its('stdout') { should match(/"secret_key"/) }
+    its('stdout') { should match(/Secrets app/) }
+  end
+
+  # Re-running must be safe and leave ownership intact
+  describe command('/usr/local/sbin/create-s3-bucket fooproject backups && echo RERUN_OK') do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should match(/already exists \(owner: fooproject\)/) }
+    its('stdout') { should match(/RERUN_OK/) }
+  end
+
+  describe command('radosgw-admin bucket stats --bucket=fooproject-backups') do
+    its('stdout') { should match(/"owner":\s*"fooproject"/) }
+  end
+end

--- a/test/integration/s3_admin/inspec.yml
+++ b/test/integration/s3_admin/inspec.yml
@@ -1,0 +1,2 @@
+name: s3_admin
+version: 0.1.0


### PR DESCRIPTION
- New s3_admin recipe deploys /root/.s3cfg and the create-s3-bucket
  script on mon hosts, gated on rgw_admin_access_key/rgw_admin_secret_key
  in the ceph data bag item
- create-s3-bucket creates the RGW user, creates <project>-<bucket> via
  the admin user, transfers ownership and verifies it; idempotent
- New s3 attributes: host_base, host_bucket, use_https
- s3_admin kitchen suite exercises the script end-to-end against a
  local RGW (endpoint must match rgw_dns_name for path-style requests)
- Accept radosgw as the rgw process name in the radosgw control

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Signed-off-by: Lance Albertson <lance@osuosl.org>
